### PR TITLE
feat/battery level labels

### DIFF
--- a/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/BatteryComponentViewModel.cs
@@ -40,31 +40,95 @@ namespace GlazeWM.Bar.Components
 
       // Display the battery level as a 100% if device has no dedicated battery.
       if (ps.BatteryFlag == 128)
-        return XamlHelper.ParseLabel(
-          _config.LabelDraining,
-          CreateVariableDict(batteryLevel),
-          this
-        );
+        return ps.BatteryLifePercent switch
+        {
+          > 0 and < 33 =>
+            XamlHelper.ParseLabel(
+              _config.LabelDrainingLow,
+              CreateVariableDict(batteryLevel),
+              this
+            ),
+          >= 33 and < 66 =>
+            XamlHelper.ParseLabel(
+              _config.LabelDrainingMedium,
+              CreateVariableDict(batteryLevel),
+              this
+            ),
+          _ =>
+            XamlHelper.ParseLabel(
+              _config.LabelDrainingHigh,
+              CreateVariableDict(batteryLevel),
+              this
+            )
+        };
 
       if (ps.ACLineStatus == 1)
-        return XamlHelper.ParseLabel(
-          _config.LabelCharging,
-          CreateVariableDict(batteryLevel),
-          this
-        );
+        return ps.BatteryLifePercent switch
+        {
+          > 0 and < 33 =>
+            XamlHelper.ParseLabel(
+              _config.LabelChargingLow,
+              CreateVariableDict(batteryLevel),
+              this
+            ),
+          >= 33 and < 66 =>
+            XamlHelper.ParseLabel(
+              _config.LabelChargingMedium,
+              CreateVariableDict(batteryLevel),
+              this
+            ),
+          _ =>
+            XamlHelper.ParseLabel(
+              _config.LabelChargingHigh,
+              CreateVariableDict(batteryLevel),
+              this
+            )
+        };
 
       if (ps.SystemStatusFlag == 1)
-        return XamlHelper.ParseLabel(
-          _config.LabelPowerSaver,
-          CreateVariableDict(batteryLevel),
-          this
-        );
+        return ps.BatteryLifePercent switch
+        {
+          > 0 and < 33 =>
+            XamlHelper.ParseLabel(
+              _config.LabelPowerSaverLow,
+              CreateVariableDict(batteryLevel),
+              this
+            ),
+          >= 33 and < 66 =>
+            XamlHelper.ParseLabel(
+              _config.LabelPowerSaverMedium,
+              CreateVariableDict(batteryLevel),
+              this
+            ),
+          _ =>
+            XamlHelper.ParseLabel(
+              _config.LabelPowerSaverHigh,
+              CreateVariableDict(batteryLevel),
+              this
+            )
+        };
 
-      return XamlHelper.ParseLabel(
-        _config.LabelDraining,
-        CreateVariableDict(batteryLevel),
-        this
-      );
+      return ps.BatteryLifePercent switch
+      {
+        > 0 and < 33 =>
+          XamlHelper.ParseLabel(
+            _config.LabelDrainingLow,
+            CreateVariableDict(batteryLevel),
+            this
+          ),
+        >= 33 and < 66 =>
+          XamlHelper.ParseLabel(
+            _config.LabelDrainingMedium,
+            CreateVariableDict(batteryLevel),
+            this
+          ),
+        _ =>
+          XamlHelper.ParseLabel(
+            _config.LabelDrainingHigh,
+            CreateVariableDict(batteryLevel),
+            this
+          )
+      };
     }
 
     public static Dictionary<string, Func<string>> CreateVariableDict(string batteryLevel)

--- a/GlazeWM.Domain/UserConfigs/BatteryComponentConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/BatteryComponentConfig.cs
@@ -17,16 +17,40 @@ namespace GlazeWM.Domain.UserConfigs
   public class BatteryComponentConfig : BarComponentConfig
   {
     /// <summary>
-    /// Formatted text to display when the device is draining battery power.
+    /// Formatted text to display when the device is draining battery power and battery level is low.
     /// </summary>
-    public string LabelDraining { get; set; } = "{battery_level}%";
+    public string LabelDrainingLow { get; set; } = "Low {battery_level}%";
     /// <summary>
-    /// Formatted text to display when the device is in power saving mode.
+    /// Formatted text to display when the device is draining battery power and battery level is medium.
     /// </summary>
-    public string LabelPowerSaver { get; set; } = "{battery_level}% (power saver)";
+    public string LabelDrainingMedium { get; set; } = "Medium {battery_level}%";
     /// <summary>
-    /// Formatted text to display when the device is connected to power.
+    /// Formatted text to display when the device is draining battery power and battery level is high.
     /// </summary>
-    public string LabelCharging { get; set; } = "{battery_level}% (charging)";
+    public string LabelDrainingHigh { get; set; } = "High {battery_level}%";
+    /// <summary>
+    /// Formatted text to display when the device is in power saving mode and battery level is low.
+    /// </summary>
+    public string LabelPowerSaverLow { get; set; } = "Low {battery_level}% (power saver)";
+    /// <summary>
+    /// Formatted text to display when the device is in power saving mode and battery level is medium.
+    /// </summary>
+    public string LabelPowerSaverMedium { get; set; } = "Medium {battery_level}% (power saver)";
+    /// <summary>
+    /// Formatted text to display when the device is in power saving mode and battery level is high.
+    /// </summary>
+    public string LabelPowerSaverHigh { get; set; } = "High {battery_level}% (power saver)";
+    /// <summary>
+    /// Formatted text to display when the device is connected to power and battery level is low.
+    /// </summary>
+    public string LabelChargingLow { get; set; } = "Low {battery_level}% (charging)";
+    /// <summary>
+    /// Formatted text to display when the device is connected to power and battery level is medium.
+    /// </summary>
+    public string LabelChargingMedium { get; set; } = "Medium {battery_level}% (charging)";
+    /// <summary>
+    /// Formatted text to display when the device is connected to power and battery level is high.
+    /// </summary>
+    public string LabelChargingHigh { get; set; } = "High {battery_level}% (charging)";
   }
 }

--- a/GlazeWM.Domain/UserConfigs/BatteryComponentConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/BatteryComponentConfig.cs
@@ -19,38 +19,38 @@ namespace GlazeWM.Domain.UserConfigs
     /// <summary>
     /// Formatted text to display when the device is draining battery power and battery level is low.
     /// </summary>
-    public string LabelDrainingLow { get; set; } = "Low {battery_level}%";
+    public string LabelDrainingLow { get; set; } = "{battery_level}% (low)";
     /// <summary>
     /// Formatted text to display when the device is draining battery power and battery level is medium.
     /// </summary>
-    public string LabelDrainingMedium { get; set; } = "Medium {battery_level}%";
+    public string LabelDrainingMedium { get; set; } = "{battery_level}% (medium)";
     /// <summary>
     /// Formatted text to display when the device is draining battery power and battery level is high.
     /// </summary>
-    public string LabelDrainingHigh { get; set; } = "High {battery_level}%";
+    public string LabelDrainingHigh { get; set; } = "{battery_level}% (high)";
     /// <summary>
     /// Formatted text to display when the device is in power saving mode and battery level is low.
     /// </summary>
-    public string LabelPowerSaverLow { get; set; } = "Low {battery_level}% (power saver)";
+    public string LabelPowerSaverLow { get; set; } = "{battery_level}% (power saver) (low)";
     /// <summary>
     /// Formatted text to display when the device is in power saving mode and battery level is medium.
     /// </summary>
-    public string LabelPowerSaverMedium { get; set; } = "Medium {battery_level}% (power saver)";
+    public string LabelPowerSaverMedium { get; set; } = "{battery_level}% (power saver) (medium)";
     /// <summary>
     /// Formatted text to display when the device is in power saving mode and battery level is high.
     /// </summary>
-    public string LabelPowerSaverHigh { get; set; } = "High {battery_level}% (power saver)";
+    public string LabelPowerSaverHigh { get; set; } = "{battery_level}% (power saver) (high)";
     /// <summary>
     /// Formatted text to display when the device is connected to power and battery level is low.
     /// </summary>
-    public string LabelChargingLow { get; set; } = "Low {battery_level}% (charging)";
+    public string LabelChargingLow { get; set; } = "{battery_level}% (charging) (low)";
     /// <summary>
     /// Formatted text to display when the device is connected to power and battery level is medium.
     /// </summary>
-    public string LabelChargingMedium { get; set; } = "Medium {battery_level}% (charging)";
+    public string LabelChargingMedium { get; set; } = "{battery_level}% (charging) (medium)";
     /// <summary>
     /// Formatted text to display when the device is connected to power and battery level is high.
     /// </summary>
-    public string LabelChargingHigh { get; set; } = "High {battery_level}% (charging)";
+    public string LabelChargingHigh { get; set; } = "{battery_level}% (charging) (high)";
   }
 }

--- a/README.md
+++ b/README.md
@@ -297,11 +297,17 @@ Additionally supported format specifiers:
 ### Bar Component: Battery
 
 The battery component displays the system's battery level in percent.
-There are three labels available that can be customized:
+There are nine labels available that can be customized:
 
-- `label_draining`: used when the system is draining battery power(i.e. not charging).
-- `label_power_saver`: used when the system is on power saving mode.
-- `label_charging`: used when the system is connected to power.
+- `label_draining_low`: used when the system is draining battery power(i.e. not charging) and the battery level is low.
+- `label_draining_medium`: used when the system is draining battery power(i.e. not charging) and the battery level is medium.
+- `label_draining_high`: used when the system is draining battery power(i.e. not charging) andthe battery level is high.
+- `label_power_saver_low`: used when the system is on power saving mode and the battery level is low.
+- `label_power_saver_medium`: used when the system is on power saving mode and the battery level is medium.
+- `label_power_saver_high`: used when the system is on power saving mode and the battery level is high.
+- `label_charging_low`: used when the system is connected to power and the battery level is low.
+- `label_charging_medium`: used when the system is connected to power and the battery level is medium.
+- `label_charging_high`: used when the system is connected to power and the battery level is high.
 
 `{battery_level}` is a variable which is replaced by the actual battery level when the label is displayed.
 
@@ -309,9 +315,15 @@ There are three labels available that can be customized:
 
 ```yaml
 - type: "battery"
-  label_draining: "{battery_level}% remaining"
-  label_power_saver: "{battery_level}% (power saver)"
-  label_charging: "{battery_level}% (charging)"
+  label_draining_low: "{battery_level}% remaining (low)"
+  label_draining_medium: "{battery_level}% remaining (medium)"
+  label_draining_high: "{battery_level}% remaining (high)"
+  label_power_saver_low: "{battery_level}% (power saver) (low)"
+  label_power_saver_medium: "{battery_level}% (power saver) (medium)"
+  label_power_saver_high: "{battery_level}% (power saver) (high)"
+  label_charging_low: "{battery_level}% (charging) (low)"
+  label_charging_medium: "{battery_level}% (charging) (medium)"
+  label_charging_high: "{battery_level}% (charging) (high)"
 ```
 
 ### Bar Component: CPU Usage


### PR DESCRIPTION
## Description

I have added more labels to the battery bar component. This allows using different icons for different battery levels. 

 ## Example config

```yaml
 - type: "battery"
   label_draining_low: "{battery_level}% remaining (low)"
   label_draining_medium: "{battery_level}% remaining (medium)"
   label_draining_high: "{battery_level}% remaining (high)"
   label_power_saver_low: "{battery_level}% (power saver) (low)"
   label_power_saver_medium: "{battery_level}% (power saver) (medium)"
   label_power_saver_high: "{battery_level}% (power saver) (high)"
   label_charging_low: "{battery_level}% (charging) (low)"
   label_charging_medium: "{battery_level}% (charging) (medium)"
   label_charging_high: "{battery_level}% (charging) (high)"
```

You can replace (low), (medium), (high) with appropriate icons.