### PR TITLE
fix(cursor_follows_focus): do not move cursor to 0,0 when focusing workspace with a maximized window

### DIFF
--- a/GlazeWM.Domain/Containers/CommandHandlers/CenterCursorOnContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/CenterCursorOnContainerHandler.cs
@@ -1,3 +1,4 @@
+using GlazeWM.Domain.Windows;
 using GlazeWM.Domain.Containers.Commands;
 using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Infrastructure.Bussing;
@@ -18,7 +19,7 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
     {
       var isEnabled = _userConfigService.GeneralConfig.CursorFollowsFocus;
 
-      if (!isEnabled || command.TargetContainer.IsDetached() || command.TargetContainer.FocusIndex < 0)
+      if (!isEnabled || command.TargetContainer.IsDetached() || command.TargetContainer is MaximizedWindow || command.TargetContainer.FocusIndex < 0)
         return CommandResponse.Ok;
 
       var targetRect = command.TargetContainer.ToRect();

--- a/GlazeWM.Domain/Containers/CommandHandlers/FocusInDirectionHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/FocusInDirectionHandler.cs
@@ -29,6 +29,9 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
       var direction = command.Direction;
       var focusedContainer = _containerService.FocusedContainer;
 
+      if (focusedContainer is MaximizedWindow)
+        return CommandResponse.Ok;
+
       var focusTarget = GetFocusTarget(focusedContainer, direction);
 
       if (focusTarget is null || focusTarget == focusedContainer)


### PR DESCRIPTION
fixes #470 