### PR TITLE
feat: make elevating process in execution an option

### DIFF
--- a/GlazeWM.Domain/Common/CommandHandlers/ExecProcessHandler.cs
+++ b/GlazeWM.Domain/Common/CommandHandlers/ExecProcessHandler.cs
@@ -1,6 +1,6 @@
 using System;
-using System.IO;
 using System.Diagnostics;
+using System.IO;
 using System.Windows.Forms;
 using GlazeWM.Domain.Common.Commands;
 using GlazeWM.Infrastructure.Bussing;

--- a/GlazeWM.Domain/Common/CommandHandlers/ExecProcessHandler.cs
+++ b/GlazeWM.Domain/Common/CommandHandlers/ExecProcessHandler.cs
@@ -1,8 +1,10 @@
 using System;
+using System.IO;
 using System.Diagnostics;
 using System.Windows.Forms;
 using GlazeWM.Domain.Common.Commands;
 using GlazeWM.Infrastructure.Bussing;
+using static GlazeWM.Infrastructure.WindowsApi.WindowsApiService;
 
 namespace GlazeWM.Domain.Common.CommandHandlers
 {
@@ -12,21 +14,55 @@ namespace GlazeWM.Domain.Common.CommandHandlers
     {
       var processName = command.ProcessName;
       var args = command.Args;
+      var shouldElevated = command.ShouldElevated;
 
       try
       {
-        using var process = new Process();
-        process.StartInfo = new ProcessStartInfo
+        if (shouldElevated)
         {
-          // Expand env variables in the process name (eg. "%ProgramFiles%").
-          FileName = Environment.ExpandEnvironmentVariables(processName),
-          Arguments = string.Join(" ", args),
-          UseShellExecute = true,
-          // Set user profile directory as the working dir. This affects the starting directory
-          // of terminal processes (eg. CMD, Git bash, etc).
-          WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-        };
-        process.Start();
+          using var process = new Process();
+          process.StartInfo = new ProcessStartInfo
+          {
+            // Expand env variables in the process name (eg. "%ProgramFiles%").
+            FileName = Environment.ExpandEnvironmentVariables(processName),
+            Arguments = string.Join(" ", args),
+            UseShellExecute = true,
+            Verb = "runas",
+            // Set user profile directory as the working dir. This affects the starting directory
+            // of terminal processes (eg. CMD, Git bash, etc).
+            WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+          };
+          process.Start();
+        }
+        else
+        {
+          // a little trick to exec without elevation if GlazeWM is in Admin mode
+          // create a shortcut of the process and open it with explorer.
+          var fileName = Environment.ExpandEnvironmentVariables(processName);
+          var arguments = string.Join(" ", args);
+
+          var profilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+          var savePath = Path.Combine(profilePath, "temp.lnk");
+
+          CreateShortcut(fileName, arguments, savePath);
+
+          var explorerProcess = new Process
+          {
+            StartInfo = new ProcessStartInfo
+            {
+              FileName = "explorer.exe",
+              Arguments = savePath,
+              UseShellExecute = true,
+            }
+          };
+          explorerProcess.Start();
+          // delete the shortcut after it's been opened
+
+          // no bug during tests, but it slows down the open speed
+          // perhaps there's a better way to handle the potential race condition?
+          explorerProcess.WaitForExit();
+          File.Delete(savePath);
+        }
       }
       catch (Exception exception)
       {

--- a/GlazeWM.Domain/Common/Commands/ExecProcessCommand.cs
+++ b/GlazeWM.Domain/Common/Commands/ExecProcessCommand.cs
@@ -7,11 +7,13 @@ namespace GlazeWM.Domain.Common.Commands
   {
     public string ProcessName { get; }
     public List<string> Args { get; }
+    public bool ShouldElevated { get; }
 
-    public ExecProcessCommand(string processName, List<string> args)
+    public ExecProcessCommand(string processName, List<string> args, bool shouldElevated)
     {
       ProcessName = processName;
       Args = args;
+      ShouldElevated = shouldElevated;
     }
   }
 }

--- a/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
@@ -86,10 +86,8 @@ namespace GlazeWM.Domain.UserConfigs
             ? new CloseWindowCommand(subjectContainer as Window)
             : new NoopCommand(),
           "reload" => ParseReloadCommand(commandParts),
-          "exec" => new ExecProcessCommand(
-            ExtractProcessName(string.Join(" ", commandParts[1..])),
-            ExtractProcessArgs(string.Join(" ", commandParts[1..]))
-          ),
+          "sudo" => ParseExecCommand(commandParts),
+          "exec" => ParseExecCommand(commandParts),
           "ignore" => subjectContainer is Window
             ? new IgnoreWindowCommand(subjectContainer as Window)
             : new NoopCommand(),
@@ -284,6 +282,22 @@ namespace GlazeWM.Domain.UserConfigs
       return commandParts[1] switch
       {
         "config" => new ReloadUserConfigCommand(),
+        _ => throw new ArgumentException(null, nameof(commandParts)),
+      };
+    }
+
+    private static Command ParseExecCommand(string[] commandParts)
+    {
+      var shouldElevated = commandParts[0] == "sudo";
+      var keywordIndex = shouldElevated ? 1 : 0;
+      var argsIndex = keywordIndex + 1;
+      return commandParts[keywordIndex] switch
+      {
+        "exec" => new ExecProcessCommand(
+          ExtractProcessName(string.Join(" ", commandParts[argsIndex..])),
+          ExtractProcessArgs(string.Join(" ", commandParts[argsIndex..])),
+          shouldElevated
+        ),
         _ => throw new ArgumentException(null, nameof(commandParts)),
       };
     }

--- a/GlazeWM.Infrastructure/WindowsApi/WindowsApiService.cs
+++ b/GlazeWM.Infrastructure/WindowsApi/WindowsApiService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Windows.Forms;
 using GlazeWM.Infrastructure.WindowsApi.Enums;
@@ -512,6 +513,53 @@ namespace GlazeWM.Infrastructure.WindowsApi
       Console.SetError(streamWriter);
 
       return result;
+    }
+
+
+    [ComImport]
+    [Guid("00021401-0000-0000-C000-000000000046")]
+    internal class ShellLink
+    {
+    }
+
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("000214F9-0000-0000-C000-000000000046")]
+    internal interface IShellLink
+    {
+      void GetPath([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszFile, int cchMaxPath, out IntPtr pfd, int fFlags);
+      void GetIDList(out IntPtr ppidl);
+      void SetIDList(IntPtr pidl);
+      void GetDescription([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszName, int cchMaxName);
+      void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
+      void GetWorkingDirectory([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszDir, int cchMaxPath);
+      void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
+      void GetArguments([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszArgs, int cchMaxPath);
+      void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
+      void GetHotkey(out short pwHotkey);
+      void SetHotkey(short wHotkey);
+      void GetShowCmd(out int piShowCmd);
+      void SetShowCmd(int iShowCmd);
+      void GetIconLocation([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszIconPath, int cchIconPath, out int piIcon);
+      void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
+      void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, int dwReserved);
+      void Resolve(IntPtr hwnd, int fFlags);
+      void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
+    }
+
+#nullable enable
+    public static void CreateShortcut(string FileName, string Args, string SavePath)
+    {
+      var link = (IShellLink)new ShellLink();
+
+      // setup shortcut information
+      link.SetPath(FileName);
+      if (Args?.Length > 0)
+        link.SetArguments(Args);
+
+      // save it
+      var file = (IPersistFile)link;
+      file.Save(SavePath, false);
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ window_rules:
 - exit wm
 - reload config
 - close
-- exec \<process name | path to executable> (eg. `exec chrome` or `exec 'C:/Program Files/Google/Chrome/Application/chrome'`)
+- (sudo) exec \<process name | path to executable> (eg. `exec chrome` or `exec 'C:/Program Files/Google/Chrome/Application/chrome'`. Adding prefix `sudo` allows you to exec in admin mode, but if you do not explicitly state so, the process will open without elevation even if you are running an elevated `GlazeWM`)
 - ignore
 
 # Known issues


### PR DESCRIPTION
If `GlazeWM` isn’t run with administrator privileges, it can't handle certain windows properly (#456 ). However, running `cmd.exe` or any other programs in an elevated `GlazeWM` will cause it to be opened with elevated permission as well.

I've attempted a (somewhat ugly) trick by using `explorer.exe` to open a shortcut of the program, allowing the target process to remain unelevated.

But there are still two aspects I believe need consideration:
1. Is it necessary to delete the created `temp.lnk`? Although launching the new program occurs in a separate process, to avoid potential issues, `GlazeWM`'s main process still waits for `explorer.exe` to finish before deleting `temp.lnk`. This might slightly increase program startup time. If `temp.lnk` isn’t deleted (I'm unsure if users would be concerned about it), none of the aforementioned issues would arise.
2. What’s the default option for running programs? Currently, my approach is that `exec cmd.exe` spawns an unelevated process, while `sudo exec cmd.exe` invariably spawns an administrator process, regardless of whether `GlazeWM.exe` has elevated privileges.