### PR TITLE
fix: null reference exception when `Container.Parent` is null

### DIFF
--- a/GlazeWM.Domain/Containers/Container.cs
+++ b/GlazeWM.Domain/Containers/Container.cs
@@ -39,16 +39,22 @@ namespace GlazeWM.Domain.Containers
     /// <summary>
     /// Index of this container in parent's child focus order.
     /// </summary>
-    public int FocusIndex => this is RootContainer ? 0 : Parent.ChildFocusOrder.IndexOf(this);
+    public int FocusIndex => this is RootContainer ? 0 : Parent?.ChildFocusOrder?.IndexOf(this) ?? 0;
 
-    public List<Container> SelfAndSiblings => Parent.Children;
+    /// <summary>
+    /// The siblings of this container including itself.
+    /// </summary>
+    public IEnumerable<Container> SelfAndSiblings => Parent?.Children?.AsEnumerable() ?? Array.Empty<Container>();
 
-    public IEnumerable<Container> Siblings => Parent.Children.Where(children => children != this);
+    /// <summary>
+    /// The siblings of this container excluding itself.
+    /// </summary>
+    public IEnumerable<Container> Siblings => Parent?.Children?.Where(children => children != this) ?? Array.Empty<Container>();
 
     /// <summary>
     /// Index of this container amongst its siblings.
     /// </summary>
-    public int Index => Parent.Children.IndexOf(this);
+    public int Index => Parent?.Children?.IndexOf(this) ?? 0;
 
     /// <summary>
     /// Get the last focused descendant by traversing downwards.
@@ -93,7 +99,7 @@ namespace GlazeWM.Domain.Containers
         while (parent != null)
         {
           yield return parent;
-          parent = parent.Parent;
+          parent = Parent?.Parent;
         }
       }
     }


### PR DESCRIPTION
**Exception:**
```
01/16/2024 7:13:59 AM
System.NullReferenceException: Object reference not set to an instance of an object.
   at GlazeWM.Domain.Containers.Container.get_Siblings() in E:\GlazeWM\GlazeWM.Domain\Containers\Container.cs:line 46
   at GlazeWM.Domain.Containers.CommandHandlers.DetachContainerHandler.Handle(DetachContainerCommand command) in E:\GlazeWM\GlazeWM.Domain\Containers\CommandHandlers\DetachContainerHandler.cs:line 32
   at GlazeWM.Infrastructure.Bussing.Bus.Invoke[T](T command) in E:\GlazeWM\GlazeWM.Infrastructure\Bussing\Bus.cs:line 48
   at GlazeWM.Domain.Monitors.CommandHandlers.RemoveMonitorHandler.Handle(RemoveMonitorCommand command) in E:\GlazeWM\GlazeWM.Domain\Monitors\CommandHandlers\RemoveMonitorHandler.cs:line 47
   at GlazeWM.Infrastructure.Bussing.Bus.Invoke[T](T command) in E:\GlazeWM\GlazeWM.Infrastructure\Bussing\Bus.cs:line 48
   at GlazeWM.Domain.Monitors.CommandHandlers.RefreshMonitorStateHandler.Handle(RefreshMonitorStateCommand command) in E:\GlazeWM\GlazeWM.Domain\Monitors\CommandHandlers\RefreshMonitorStateHandler.cs:line 63
   at GlazeWM.Infrastructure.Bussing.Bus.Invoke[T](T command) in E:\GlazeWM\GlazeWM.Infrastructure\Bussing\Bus.cs:line 48
   at GlazeWM.Domain.Monitors.EventHandlers.DisplaySettingsChangedHandler.Handle(DisplaySettingsChangedEvent event) in E:\GlazeWM\GlazeWM.Domain\Monitors\EventHandlers\DisplaySettingsChangedHandler.cs:line 18
   at GlazeWM.Infrastructure.Bussing.Bus.Emit[T](T event) in E:\GlazeWM\GlazeWM.Infrastructure\Bussing\Bus.cs:line 87
   at GlazeWM.Infrastructure.Bussing.Bus.<>c__DisplayClass8_0`1.<EmitAsync>b__0() in E:\GlazeWM\GlazeWM.Infrastructure\Bussing\Bus.cs:line 101
```

**Background:**
* This occurs every time I wake my computer from sleep after having it previously connected to a monitor (e.g. laptop plugged into a monitor at work but not connected to a monitor when I get home). 
* Seems to be caused by a recently added method `Container.RemoveChild` where the `Parent` property is set to null.

Only thing I'm not 100% sure about is whether or not I should have set the "fallbacks" for `Index` properties to -1 or to 0? I was worried setting to -1 would cause an index out of range exceptions somewhere...