### PR TITLE
fix: crash when detaching monitor on display settings change

### DIFF
--- a/GlazeWM.Domain/Containers/Container.cs
+++ b/GlazeWM.Domain/Containers/Container.cs
@@ -41,14 +41,18 @@ namespace GlazeWM.Domain.Containers
     /// </summary>
     public int FocusIndex => this is RootContainer ? 0 : Parent.ChildFocusOrder.IndexOf(this);
 
-    public List<Container> SelfAndSiblings => Parent.Children;
+    public List<Container> SelfAndSiblings =>
+      this is RootContainer ? new List<Container>() : Parent.Children;
 
-    public IEnumerable<Container> Siblings => Parent.Children.Where(children => children != this);
+    public IEnumerable<Container> Siblings =>
+      this is RootContainer
+        ? Array.Empty<Container>()
+        : Parent.Children.Where(children => children != this);
 
     /// <summary>
     /// Index of this container amongst its siblings.
     /// </summary>
-    public int Index => Parent.Children.IndexOf(this);
+    public int Index => this is RootContainer ? 0 : Parent.Children.IndexOf(this);
 
     /// <summary>
     /// Get the last focused descendant by traversing downwards.

--- a/GlazeWM.Domain/Containers/Container.cs
+++ b/GlazeWM.Domain/Containers/Container.cs
@@ -42,7 +42,7 @@ namespace GlazeWM.Domain.Containers
     public int FocusIndex => this is RootContainer ? 0 : Parent.ChildFocusOrder.IndexOf(this);
 
     public List<Container> SelfAndSiblings =>
-      this is RootContainer ? new List<Container>() : Parent.Children;
+      this is RootContainer ? new List<Container>() { this } : Parent.Children;
 
     public IEnumerable<Container> Siblings =>
       this is RootContainer


### PR DESCRIPTION
* Correctly handle `Siblings`, `Index`, and `SelfAndSiblings` getters for the `RootContainer`.

Thanks to @maxle5 for figuring out the cause of the crash in #511 🙏 

Closes #518, #510