### PR TITLE
ci: correct asset name on GH release

### DIFF
--- a/.github/actions/release-with-artifacts/action.yaml
+++ b/.github/actions/release-with-artifacts/action.yaml
@@ -30,10 +30,10 @@ runs:
           [
             {
               "path": "artifacts/win-x64/GlazeWM.exe",
-              "name": "GlazeWM_x64_${nextRelease.gitTag}"
+              "name": "GlazeWM_x64_${nextRelease.version}.exe"
             },
             {
               "path": "artifacts/win-x86/GlazeWM.exe",
-              "name": "GlazeWM_x86_${nextRelease.gitTag}"
+              "name": "GlazeWM_x86_${nextRelease.version}.exe"
             }
           ]


### PR DESCRIPTION
* Correct asset name of GitHub releases to be consistent with previous releases.