### PR TITLE
Added 'set no_title' command to allow the user to remove the title bar from windows.

### DIFF
--- a/GlazeWM.Domain/DependencyInjection.cs
+++ b/GlazeWM.Domain/DependencyInjection.cs
@@ -66,6 +66,7 @@ namespace GlazeWM.Domain
       services.AddSingleton<ICommandHandler<ResizeWindowCommand>, ResizeWindowHandler>();
       services.AddSingleton<ICommandHandler<ResizeWindowBordersCommand>, ResizeWindowBordersHandler>();
       services.AddSingleton<ICommandHandler<SetFloatingCommand>, SetFloatingHandler>();
+      services.AddSingleton<ICommandHandler<RemoveTitleBarCommand>, RemoveTitleBarHandler>();
       services.AddSingleton<ICommandHandler<SetMaximizedCommand>, SetMaximizedHandler>();
       services.AddSingleton<ICommandHandler<SetMinimizedCommand>, SetMinimizedHandler>();
       services.AddSingleton<ICommandHandler<SetTilingCommand>, SetTilingHandler>();

--- a/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
+++ b/GlazeWM.Domain/UserConfigs/CommandParsingService.cs
@@ -52,12 +52,12 @@ namespace GlazeWM.Domain.UserConfigs
         if (regex.IsMatch(commandString))
         {
           return regex.Replace(commandString, (Match match) =>
-            match.Value.ToLowerInvariant()
+            match.Value
           );
         }
       }
 
-      return commandString.ToLowerInvariant();
+      return commandString;
     }
 
     public void ValidateCommand(string commandString)
@@ -235,6 +235,9 @@ namespace GlazeWM.Domain.UserConfigs
           : new NoopCommand(),
         "height" => subjectContainer is Window
           ? new SetWindowSizeCommand(subjectContainer as Window, ResizeDimension.Height, commandParts[2])
+          : new NoopCommand(),
+        "no_title" => subjectContainer is Window
+          ? new RemoveTitleBarCommand(subjectContainer as Window)
           : new NoopCommand(),
         _ => throw new ArgumentException(null, nameof(commandParts)),
       };

--- a/GlazeWM.Domain/Windows/CommandHandlers/RemoveTitleBarHandler.cs
+++ b/GlazeWM.Domain/Windows/CommandHandlers/RemoveTitleBarHandler.cs
@@ -1,0 +1,47 @@
+using GlazeWM.Domain.Windows.Commands;
+using GlazeWM.Infrastructure.Bussing;
+using GlazeWM.Infrastructure.WindowsApi;
+
+namespace GlazeWM.Domain.Windows.CommandHandlers
+{
+  internal sealed class RemoveTitleBarHandler : ICommandHandler<RemoveTitleBarCommand>
+  {
+    private readonly Bus _bus;
+
+    public RemoveTitleBarHandler(Bus bus)
+    {
+      _bus = bus;
+    }
+
+    public CommandResponse Handle(RemoveTitleBarCommand command)
+    {
+      var window = command.Window;
+
+      var result1 = WindowsApiService.SetWindowLong(
+        window.Handle,
+        WindowsApiService.GWLSTYLE,
+        unchecked((int)WindowsApiService.WindowStyles.PopupWindow)
+      );
+
+      if (result1 == 0)
+      {
+        return CommandResponse.Fail;
+      }
+
+      uint preference = 2;
+      var result2 = WindowsApiService.DwmSetWindowAttribute(
+        window.Handle,
+        (uint)WindowsApiService.DwmWindowAttribute.WindowCornerPreference,
+        ref preference,
+        sizeof(int)
+      );
+
+      if (result2 == 0)
+      {
+        return CommandResponse.Fail;
+      }
+
+      return CommandResponse.Ok;
+    }
+  }
+}

--- a/GlazeWM.Domain/Windows/Commands/RemoveTitleBarCommand.cs
+++ b/GlazeWM.Domain/Windows/Commands/RemoveTitleBarCommand.cs
@@ -1,0 +1,14 @@
+using GlazeWM.Infrastructure.Bussing;
+
+namespace GlazeWM.Domain.Windows.Commands
+{
+  public class RemoveTitleBarCommand : Command
+  {
+    public Window Window { get; }
+
+    public RemoveTitleBarCommand(Window window)
+    {
+      Window = window;
+    }
+  }
+}

--- a/GlazeWM.Infrastructure/WindowsApi/WindowsApiService.cs
+++ b/GlazeWM.Infrastructure/WindowsApi/WindowsApiService.cs
@@ -139,6 +139,7 @@ namespace GlazeWM.Infrastructure.WindowsApi
       Cloak,
       Cloaked,
       FreezeRepresentation,
+      WindowCornerPreference = 33,
       Last
     }
 
@@ -172,18 +173,11 @@ namespace GlazeWM.Infrastructure.WindowsApi
         : GetWindowLongPtr32(hWnd, index);
     }
 
-    [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
-    private static extern IntPtr SetWindowLongPtr32(IntPtr hWnd, int index, IntPtr newLong);
+    [DllImport("user32.dll")]
+    public static extern IntPtr SetWindowLong(IntPtr hWnd, int index, int newLong);
 
-    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
-    private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int index, IntPtr newLong);
-
-    public static IntPtr SetWindowLongPtr(IntPtr hWnd, int index, IntPtr newLong)
-    {
-      return Environment.Is64BitProcess
-        ? SetWindowLongPtr64(hWnd, index, newLong)
-        : SetWindowLongPtr32(hWnd, index, newLong);
-    }
+    [DllImport("user32.dll")]
+    public static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int index, IntPtr newLong);
 
     [DllImport("user32.dll", SetLastError = true)]
     public static extern bool SetWindowPos(


### PR DESCRIPTION
This includes minor changes to WindowsApiService.cs, because when using it, I found the SetWindowLong function unaccessible on 64 bit machines, which is wrong, since it actually does not consider 32 bit pointers, but just values wich are 32 bit even on 64bit systems. This might break compatibilty with 32 bit systems, but Id be surprised to hear if that compatibilty existed in the first place.

Note: This unfortunately makes the window no longer resizeable with the mouse due to Windows' **great** design, but I dont think thats a big issue since this is a tiling window manager lol.