### PR TITLE
feat: added max title length option to window title component

### DIFF
--- a/GlazeWM.Bar/Components/WindowTitleComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/WindowTitleComponentViewModel.cs
@@ -56,8 +56,7 @@ namespace GlazeWM.Bar.Components
     {
       var variableDictionary = new Dictionary<string, Func<string>>()
       {
-      // TODO: Make truncate max length configurable from config.
-        { "window_title", () => Truncate(windowTitle, 60) }
+        { "window_title", () => Truncate(windowTitle, _config.MaxTitleLength) }
       };
 
       return XamlHelper.ParseLabel(_config.Label, variableDictionary, this);
@@ -65,7 +64,7 @@ namespace GlazeWM.Bar.Components
 
     public static string Truncate(string value, int maxLength, string truncationSuffix = "…")
     {
-      return value?.Length > maxLength
+      return value?.Length > maxLength && maxLength >= 0
         ? string.Concat(value.AsSpan(0, maxLength), truncationSuffix)
         : value;
     }

--- a/GlazeWM.Domain/UserConfigs/WindowTitleComponentConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/WindowTitleComponentConfig.cs
@@ -6,5 +6,10 @@ namespace GlazeWM.Domain.UserConfigs
     /// Label assigned to the window title component.
     /// </summary>
     public string Label { get; set; } = "{window_title}";
+
+    /// <summary>
+    /// The maximum length after which the window title will be truncated; if set to -1, the title will not be truncated.
+    /// </summary>
+    public int MaxTitleLength { get; set; } = 60;
   }
 }

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Using the example of padding:
 - [Image](#bar-component-image)
 - [System Tray](#bar-component-system-tray)
 - [Music](#bar-component-music)
+- [Title](#bar-component-title)
 
 #### Bar component: Clock
 
@@ -496,6 +497,15 @@ Displays currently playing music.
   label_playing: "{song_title} - {artist_name} ▶"
   max_title_length: 20
   max_artist_length: 20
+```
+
+#### Bar component: Title
+
+Displays the window title of the currently-selected window.
+
+```yaml
+- type: "window title"
+  max_title_length: 60
 ```
 
 ## Mixing font properties within a label


### PR DESCRIPTION
Added MaxTitleLength to the WindowTitleComponent, 
updated the README with a section for the `window title` configuration in the user config, 
retained the default max length of 60, 
customizable from the user config with `max_title_length`,
compiled and tested.