### PR TITLE
feat: option to start system tray component expanded

### DIFF
--- a/GlazeWM.Bar/Components/SystemTrayComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/SystemTrayComponentViewModel.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
-using System.Windows.Input;
-using GlazeWM.Bar.Common;
 using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Infrastructure;
 using ManagedShell;
@@ -18,7 +15,7 @@ namespace GlazeWM.Bar.Components
     private readonly ShellManager _shellManager =
       ServiceLocator.GetRequiredService<ShellManager>();
 
-    private bool _isExpanded = true;
+    private bool _isExpanded;
     public bool IsExpanded
     {
       get => _isExpanded;
@@ -53,6 +50,8 @@ namespace GlazeWM.Bar.Components
       SystemTrayComponentConfig config) : base(parentViewModel, config)
     {
       _config = config;
+
+      _isExpanded = _config.Expanded;
 
       // Subscribe to collection changes of pinned/unpinned tray icons.
       _shellManager.NotificationArea.UnpinnedIcons.CollectionChanged +=

--- a/GlazeWM.Domain/UserConfigs/SystemTrayComponentConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/SystemTrayComponentConfig.cs
@@ -11,5 +11,10 @@ namespace GlazeWM.Domain.UserConfigs
     /// Collapse to show only pinned icons.
     /// </summary>
     public string LabelCollapseText { get; set; } = "<attr ff='pack://application:,,,/Resources/#Material Icons'></attr>";
+
+    /// <summary>
+    /// Expanded on startup
+    /// </summary>
+    public bool Expanded { get; set; } = true;
   }
 }

--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Use `Alt+Click` to pin and un-pin an icon.
 - type: "system tray"
   label_expand_text: "<"
   label_collapse_text: ">"
+  expanded: true
 ```
 
 #### Bar component: Music


### PR DESCRIPTION
Adds the option to have the system tray bar component be collapsed or expanded from start-up.
Fixes #441