### PR TITLE
Corrected typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Keybindings with <kbd>Alt</kbd>+<kbd>Shift</kbd> pressed:
 
 ![Alt+shift key pressed - with keybindings](https://user-images.githubusercontent.com/34844898/194635089-d5ed152b-1527-43e8-a69c-4e154b97a207.png)
 
-Apart from the `Alt+Shift+E` binding for exiting GlazeWM, it's also possibly to safely exit via the system tray icon.
+Apart from the `Alt+Shift+E` binding for exiting GlazeWM, it's also possible to safely exit via the system tray icon.
 
 ## Focus Window Border configuration
 


### PR DESCRIPTION
Under default key bindings, at the end of the section, changed "it's also possibly to safely" to "it's also possible to safely".