### PR TITLE
feat: Allow Mouse to Follow Cursor onto Empty Workspace and Simulate Mouse Click to Facilitate Launching Flow Launcher Search

### DIFF
--- a/GlazeWM.App.WindowManager/WmStartup.cs
+++ b/GlazeWM.App.WindowManager/WmStartup.cs
@@ -6,6 +6,7 @@ using GlazeWM.Domain.UserConfigs;
 using GlazeWM.Domain.UserConfigs.Commands;
 using GlazeWM.Domain.Windows;
 using GlazeWM.Domain.Windows.Commands;
+using GlazeWM.Domain.Workspaces;
 using GlazeWM.Infrastructure.Bussing;
 using GlazeWM.Infrastructure.Common;
 using GlazeWM.Infrastructure.Common.Commands;
@@ -119,7 +120,7 @@ namespace GlazeWM.App.WindowManager
             .Select((@event) => @event.FocusedContainer);
 
           focusedContainerMoved.Merge(nativeFocusSynced)
-            .Where(container => container is Window)
+            .Where(container => container is Window or Workspace)
             .Subscribe((window) => _bus.InvokeAsync(new CenterCursorOnContainerCommand(window)));
         }
 

--- a/GlazeWM.Domain/Containers/CommandHandlers/CenterCursorOnContainerHandler.cs
+++ b/GlazeWM.Domain/Containers/CommandHandlers/CenterCursorOnContainerHandler.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Runtime.InteropServices;
 using GlazeWM.Domain.Containers.Commands;
 using GlazeWM.Domain.UserConfigs;
+using GlazeWM.Domain.Workspaces;
 using GlazeWM.Infrastructure.Bussing;
 using static GlazeWM.Infrastructure.WindowsApi.WindowsApiService;
 
@@ -28,6 +31,23 @@ namespace GlazeWM.Domain.Containers.CommandHandlers
       var centerY = targetRect.Y + (targetRect.Height / 2);
 
       SetCursorPos(centerX, centerY);
+
+      var container = command.TargetContainer;
+
+      if (container is Workspace)
+      {
+        var inputs = new INPUT[1];
+        inputs[0].type = 0;
+        inputs[0].data.mi.dx = centerX;
+        inputs[0].data.mi.dy = centerY;
+        inputs[0].data.mi.dwFlags = MOUSEEVENTF_LEFTDOWN | MOUSEEVENTF_LEFTUP;
+
+        var result = SendInput(1, inputs, Marshal.SizeOf(typeof(INPUT)));
+        if (result == 0)
+        {
+          throw new Exception("Error occurred while simulating mouse click. This is a bug.");
+        }
+      }
 
       return CommandResponse.Ok;
     }

--- a/GlazeWM.Infrastructure/WindowsApi/WindowsApiService.cs
+++ b/GlazeWM.Infrastructure/WindowsApi/WindowsApiService.cs
@@ -238,6 +238,41 @@ namespace GlazeWM.Infrastructure.WindowsApi
     [DllImport("user32.dll")]
     public static extern bool SetCursorPos(int x, int y);
 
+    public const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+    public const uint MOUSEEVENTF_LEFTUP = 0x0004;
+
+    [DllImport("user32.dll")]
+    public static extern uint SendInput(
+        uint nInputs,
+        INPUT[] pInputs,
+        int cbSize
+    );
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct INPUT
+    {
+      public uint type;
+      public INPUTUNION data;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct INPUTUNION
+    {
+      [FieldOffset(0)]
+      public MOUSEINPUT mi;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MOUSEINPUT
+    {
+      public int dx;
+      public int dy;
+      public uint mouseData;
+      public uint dwFlags;
+      public uint time;
+      public IntPtr dwExtraInfo;
+    }
+
     /// <summary>
     /// Params that can be passed to `ShowWindow`. Only the subset of flags relevant to
     /// this application are included.


### PR DESCRIPTION
Here's my attempt to address Issue #554 which allows Flow Launcher to launch search on an empty workspace as well as other programs that do not like that funky state of a Workspace that has been focused but not clicked (e.g., Windows Screenshot Tool). 

I'm an avid user of i3 and am very happy that this project exists which allows me to have nearly the same experience on my Windows machine. Thanks and kudos to the devs who started this! 

## Overview of Changes:
- **Enable mouse cursor to follow onto a workspace that is empty**.
  - After debugging the console output, I noticed that when the focus is changed to a workspace that has no active windows, the `FocusedContainer` is a `GlazeWM.Domains.Workspaces.Workspace` type container. I modified the `.Where()` on WmStartup.cs:123 to also invoke the `CenterCursorOnContainerCommand` when this happens. This allows for the cursor to follow onto an empty workspace.
- **Simulates Mouse Click only when Focus is changed to an Empty Workspace**.
  - Even after getting the mouse cursor to follow onto an empty workspace, I was still not able to launch the Search Window of Flow Launcher after focusing. It appears that the empty workspace is not actually focused (?) since I can still see the title of the last focused window in the Polybar even though the Workspace Number in the polybar is showing active.
![image](https://github.com/glzr-io/glazewm/assets/12095647/2b46be91-feef-4425-b8c4-656a5743562d)
![image](https://github.com/glzr-io/glazewm/assets/12095647/441df350-e072-4295-8b30-8ec16f00d404)
(I can't even initiate the Windows Screenshot tool (WIN+SHIFT+S) to get a full screenshot of the highlighted workspace number and the title of the last window on my polybar when in this state so it's not just Flow Launcher that's having issues.)
When I click on the empty workspace, that seems to effectively focus the workspace and the polybar title is cleared and I can launch Flow Launcher (and the Windows Screenshot tool).
  - I added `SendInput` along with the required structs for Mouse Input and added that to the `CenterCursorOnContainerHandler` with a check that the container is of type `Workspace`. 



 