### PR TITLE
feat: added MaxWindowTitleLength to WindowTitle Component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,4 @@ _Pvt_Extensions
 
 # IDEA files
 .idea/
+GlazeWM.exe

--- a/GlazeWM.Bar/Components/WindowTitleComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/WindowTitleComponentViewModel.cs
@@ -57,7 +57,7 @@ namespace GlazeWM.Bar.Components
       var variableDictionary = new Dictionary<string, Func<string>>()
       {
       // TODO: Make truncate max length configurable from config.
-        { "window_title", () => Truncate(windowTitle, 60) }
+        { "window_title", () => Truncate(windowTitle, _config.MaxWindowTitleLength) }
       };
 
       return XamlHelper.ParseLabel(_config.Label, variableDictionary, this);

--- a/GlazeWM.Domain/UserConfigs/WindowTitleComponentConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/WindowTitleComponentConfig.cs
@@ -6,5 +6,6 @@ namespace GlazeWM.Domain.UserConfigs
     /// Label assigned to the window title component.
     /// </summary>
     public string Label { get; set; } = "{window_title}";
+    public int MaxWindowTitleLength { get; set; } = 60;
   }
 }

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Using the example of padding:
 - [Image](#bar-component-image)
 - [System Tray](#bar-component-system-tray)
 - [Music](#bar-component-music)
+- [Window Title](#bar-component-window-title)
 
 #### Bar component: Clock
 
@@ -496,6 +497,15 @@ Displays currently playing music.
   label_playing: "{song_title} - {artist_name} ▶"
   max_title_length: 20
   max_artist_length: 20
+```
+
+#### Bar component: Window Title
+
+Displays the title of the currently-selected window.
+
+```yaml
+- type: "window title"
+  max_window_title_length: 60
 ```
 
 ## Mixing font properties within a label


### PR DESCRIPTION
Completely forgot that the original PR was still open when I deleted the original fork, so I just remade the changes in a new fork. If you want it simplified to `max_title_length` instead, just let me know.