### PR TITLE
feat: added DefaultLabel to BindingMode Component

### DIFF
--- a/GlazeWM.Bar/Components/BindingModeComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/BindingModeComponentViewModel.cs
@@ -21,11 +21,20 @@ namespace GlazeWM.Bar.Components
     /// </summary>
     public string ActiveBindingMode => _containerService.ActiveBindingMode;
 
+    private string GetVisibility()
+    {
+      if (_config.DefaultLabel.Length == 0)
+      {
+        return ActiveBindingMode is null ? "Collapsed" : "Visible";
+      }
+
+      return "Visible";
+    }
+
     /// <summary>
     /// Hide component when no binding mode is active.
     /// </summary>
-    public override string Visibility =>
-      _config.DefaultLabel is "" ? "Collapsed" : "Visible"; //Uses the config value as the deciding factor on visibility, seems to work
+    public override string Visibility => GetVisibility();
 
     private LabelViewModel _label;
     public LabelViewModel Label

--- a/GlazeWM.Bar/Components/BindingModeComponentViewModel.cs
+++ b/GlazeWM.Bar/Components/BindingModeComponentViewModel.cs
@@ -25,7 +25,7 @@ namespace GlazeWM.Bar.Components
     /// Hide component when no binding mode is active.
     /// </summary>
     public override string Visibility =>
-      ActiveBindingMode is null ? "Collapsed" : "Visible";
+      _config.DefaultLabel is "" ? "Collapsed" : "Visible"; //Uses the config value as the deciding factor on visibility, seems to work
 
     private LabelViewModel _label;
     public LabelViewModel Label
@@ -39,13 +39,14 @@ namespace GlazeWM.Bar.Components
       BindingModeComponentConfig config) : base(parentViewModel, config)
     {
       _config = config;
+      Label = CreateLabel(_config.DefaultLabel); //Propagates the default tag on startup
 
       _bus.Events.OfType<BindingModeChangedEvent>()
         .TakeUntil(_parentViewModel.WindowClosing)
         .Subscribe((@event) =>
         {
           OnPropertyChanged(nameof(Visibility));
-          Label = CreateLabel(@event.NewBindingMode);
+          Label = ActiveBindingMode is null ? CreateLabel(_config.DefaultLabel) : CreateLabel(@event.NewBindingMode); //Ensures that Label reverts to default tag once binding mode is exited.
         });
     }
 

--- a/GlazeWM.Domain/UserConfigs/BindingModeComponentConfig.cs
+++ b/GlazeWM.Domain/UserConfigs/BindingModeComponentConfig.cs
@@ -1,3 +1,5 @@
+using System.Security.Policy;
+
 namespace GlazeWM.Domain.UserConfigs
 {
   public class BindingModeComponentConfig : BarComponentConfig
@@ -6,5 +8,7 @@ namespace GlazeWM.Domain.UserConfigs
     /// Label assigned to the binding mode component.
     /// </summary>
     public string Label { get; set; } = "{binding_mode}";
+
+    public string DefaultLabel { get; set; } = "";
   }
 }


### PR DESCRIPTION
The motivation is pretty simple: if you use separators for your bar, there will be a blank space between two separators where the binding mode display is. The reason is that while it's set up to collapse the width when there is no binding mode by default, the bar still reserves this space. So, I've added in a config variable, `default_label`, to optionally display a tag whenever the user does not have a binding mode selected.

Let me know if I need to make any changes.