### PR TITLE
feat: Focus command to focus on specific monitor by index

### DIFF
--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -19,6 +19,7 @@ use crate::{
     traits::CommonGetters,
     Container,
   },
+  monitors::commands::focus_monitor,
   user_config::{FloatingStateConfig, FullscreenStateConfig, UserConfig},
   windows::{
     commands::{
@@ -300,6 +301,10 @@ impl InvokeCommand {
             state,
             config,
           )?;
+        }
+
+        if let Some(monitor) = &args.monitor {
+          focus_monitor(monitor, state, config)?;
         }
 
         if args.next_workspace {
@@ -645,6 +650,9 @@ pub struct InvokeFocusCommand {
 
   #[clap(long)]
   workspace: Option<String>,
+
+  #[clap(long)]
+  monitor: Option<usize>,
 
   #[clap(long)]
   next_workspace: bool,

--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -303,8 +303,8 @@ impl InvokeCommand {
           )?;
         }
 
-        if let Some(monitor) = &args.monitor {
-          focus_monitor(monitor, state, config)?;
+        if let Some(monitor_index) = &args.monitor {
+          focus_monitor(*monitor_index, state, config)?;
         }
 
         if args.next_workspace {

--- a/packages/wm/src/monitors/commands/focus_monitor.rs
+++ b/packages/wm/src/monitors/commands/focus_monitor.rs
@@ -1,0 +1,39 @@
+use crate::{
+  containers::traits::CommonGetters,
+  user_config::UserConfig,
+  wm_state::WmState,
+  workspaces::{commands::focus_workspace, WorkspaceTarget},
+};
+
+/// Focuses a monitor by a given monitor index.
+pub fn focus_monitor(
+  target: &usize,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<()> {
+  let monitors = state.monitors();
+
+  let target_monitor = monitors.get(target.clone());
+
+  // if there are fewer monitors than the index provided error out and bail
+  // early from function
+  if target_monitor.is_none() {
+    anyhow::bail!("target index greater than number of monitors");
+  }
+
+  let target_monitor = target_monitor.unwrap();
+
+  if target_monitor.has_focus(None) {
+    return Ok(());
+  }
+
+  let displayed_workspace = target_monitor.displayed_workspace().unwrap();
+
+  focus_workspace(
+    WorkspaceTarget::Name(displayed_workspace.config().name),
+    state,
+    config,
+  )?;
+
+  Ok(())
+}

--- a/packages/wm/src/monitors/commands/mod.rs
+++ b/packages/wm/src/monitors/commands/mod.rs
@@ -2,8 +2,10 @@ mod add_monitor;
 mod remove_monitor;
 mod sort_monitors;
 mod update_monitor;
+mod focus_monitor;
 
 pub use add_monitor::*;
 pub use remove_monitor::*;
 pub use sort_monitors::*;
 pub use update_monitor::*;
+pub use focus_monitor::*;


### PR DESCRIPTION
This PR is to add a command option to the `focus` command that allows you to focus on a specific monitor by index.
And example usage of this would be:
```
glazewm.exe command focus --monitor 1
```
This would focus on the second monitor.
The indexing is zero-based, so the first monitor would be monitor 0.