### PR TITLE
docs: Update readme with how to correctly start GlazeWM with a custom config path, closes #688

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The [default config](https://github.com/glzr-io/glazewm/blob/main/resources/asse
 To use a different config file location, you can launch the GlazeWM executable with the CLI argument `--config="..."`, like so:
 
 ```sh
-./glazewm.exe --config="C:\<PATH_TO_CONFIG>\config.yaml"
+./glazewm.exe start --config="C:\<PATH_TO_CONFIG>\config.yaml"
 ```
 
 ### Config: General


### PR DESCRIPTION
The documentation for starting GlazeWM with a custom config path was missing `start` in `glazewm start --config="<custom path>"`

Old (bad) documentation: `./glazewm.exe --config="C:\<PATH_TO_CONFIG>\config.yaml"`
New (fixed) documentation: `./glazewm.exe start --config="C:\<PATH_TO_CONFIG>\config.yaml"`

Closes issue [@688](https://github.com/glzr-io/glazewm/issues/688)