### PR TITLE
feat: Adding Winget auto releaser, closes #652

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,3 +59,10 @@ jobs:
                 "label": "${nextRelease.gitTag} Installer (standalone arm64)"
               }
             ]
+            
+      - name: Winget Release
+        uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: glzr-io.glazewm
+          installers-regex: 'glazewm-[0-9.]+\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Related issue #652 

**Important**- this PR and the Winget releaser expects the following prerequisites which only maintainers can do:
- The existence of a `Classic Personal Access Token` (PAT) with `public_repo` scope stored in a variable/secret called `WINGET_TOKEN`
- The existence of a fork of `microsoft/winget-pkgs` under the same account of this repository

The prerequisites above should be done via the Github account of the repo, outside of the PR.
