### PR TITLE
feat: add command `set-tiling-direction [vertical|horizontal]`

### DIFF
--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -227,8 +227,10 @@ pub enum InvokeCommand {
   ToggleMinimized,
   ToggleTiling,
   ToggleTilingDirection,
-  SetTilingDirectionVertical,
-  SetTilingDirectionHorizontal,
+  SetTilingDirection {
+    #[clap(required = true)]
+    tiling_direction: TilingDirection,
+  },
   WmCycleFocus {
     #[clap(long, default_value_t = false)]
     omit_fullscreen: bool,
@@ -577,18 +579,14 @@ impl InvokeCommand {
       InvokeCommand::ToggleTilingDirection => {
         toggle_tiling_direction(subject_container, state, config)
       }
-      InvokeCommand::SetTilingDirectionVertical => set_tiling_direction(
-        subject_container,
-        state,
-        config,
-        TilingDirection::Vertical,
-      ),
-      InvokeCommand::SetTilingDirectionHorizontal => set_tiling_direction(
-        subject_container,
-        state,
-        config,
-        TilingDirection::Horizontal,
-      ),
+      InvokeCommand::SetTilingDirection { tiling_direction } => {
+        set_tiling_direction(
+          subject_container,
+          state,
+          config,
+          tiling_direction.clone(),
+        )
+      }
       InvokeCommand::WmCycleFocus {
         omit_fullscreen,
         omit_minimized,

--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -12,10 +12,12 @@ use crate::{
       cycle_focus, disable_binding_mode, enable_binding_mode,
       reload_config, shell_exec,
     },
-    Direction, LengthValue, RectDelta,
+    Direction, LengthValue, RectDelta, TilingDirection,
   },
   containers::{
-    commands::{focus_in_direction, toggle_tiling_direction},
+    commands::{
+      focus_in_direction, set_tiling_direction, toggle_tiling_direction,
+    },
     traits::CommonGetters,
     Container,
   },
@@ -225,6 +227,8 @@ pub enum InvokeCommand {
   ToggleMinimized,
   ToggleTiling,
   ToggleTilingDirection,
+  SetTilingDirectionVertical,
+  SetTilingDirectionHorizontal,
   WmCycleFocus {
     #[clap(long, default_value_t = false)]
     omit_fullscreen: bool,
@@ -573,6 +577,18 @@ impl InvokeCommand {
       InvokeCommand::ToggleTilingDirection => {
         toggle_tiling_direction(subject_container, state, config)
       }
+      InvokeCommand::SetTilingDirectionVertical => set_tiling_direction(
+        subject_container,
+        state,
+        config,
+        TilingDirection::Vertical,
+      ),
+      InvokeCommand::SetTilingDirectionHorizontal => set_tiling_direction(
+        subject_container,
+        state,
+        config,
+        TilingDirection::Horizontal,
+      ),
       InvokeCommand::WmCycleFocus {
         omit_fullscreen,
         omit_minimized,

--- a/packages/wm/src/containers/commands/toggle_tiling_direction.rs
+++ b/packages/wm/src/containers/commands/toggle_tiling_direction.rs
@@ -88,34 +88,14 @@ pub fn set_tiling_direction(
   container: Container,
   state: &mut WmState,
   config: &UserConfig,
-  direction: TilingDirection,
+  tiling_direction: TilingDirection,
 ) -> anyhow::Result<()> {
-  let current_direction = tiling_direction(&container)?;
-  if current_direction != direction {
-    toggle_tiling_direction(container, state, config)
-  }
-  else {
-    Ok(())
-  }
-}
-
-fn tiling_direction(
-  container: &Container,
-) -> anyhow::Result<TilingDirection> {
-  return match container {
-    Container::TilingWindow(tiling_window) =>
-      window_direction(&tiling_window),
-    Container::Workspace(workspace) =>
-      Ok(workspace.tiling_direction()),
-    _ => panic!("No direction container")
-  }
-}
-
-fn window_direction(
-  tiling_window: &TilingWindow,
-) -> anyhow::Result<TilingDirection> {
-  let parent = tiling_window
+  let direction_container = container
     .direction_container()
     .context("No direction container.")?;
-  Ok(parent.tiling_direction())
+
+  match direction_container.tiling_direction() == tiling_direction {
+    true => Ok(()),
+    false => toggle_tiling_direction(container, state, config)
+  }
 }

--- a/packages/wm/src/containers/commands/toggle_tiling_direction.rs
+++ b/packages/wm/src/containers/commands/toggle_tiling_direction.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 
 use super::{flatten_split_container, wrap_in_split_container};
 use crate::{
+  common::TilingDirection,
   containers::{
     traits::{CommonGetters, TilingDirectionGetters},
     Container, DirectionContainer, SplitContainer,
@@ -81,4 +82,40 @@ fn toggle_window_direction(
   )?;
 
   Ok(split_container.into())
+}
+
+pub fn set_tiling_direction(
+  container: Container,
+  state: &mut WmState,
+  config: &UserConfig,
+  direction: TilingDirection,
+) -> anyhow::Result<()> {
+  let current_direction = tiling_direction(&container)?;
+  if current_direction != direction {
+    toggle_tiling_direction(container, state, config)
+  }
+  else {
+    Ok(())
+  }
+}
+
+fn tiling_direction(
+  container: &Container,
+) -> anyhow::Result<TilingDirection> {
+  return match container {
+    Container::TilingWindow(tiling_window) =>
+      window_direction(&tiling_window),
+    Container::Workspace(workspace) =>
+      Ok(workspace.tiling_direction()),
+    _ => panic!("No direction container")
+  }
+}
+
+fn window_direction(
+  tiling_window: &TilingWindow,
+) -> anyhow::Result<TilingDirection> {
+  let parent = tiling_window
+    .direction_container()
+    .context("No direction container.")?;
+  Ok(parent.tiling_direction())
 }


### PR DESCRIPTION
I added the two commands `set-tiling-direction-vertical` and `set-tiling-direction-horizontal`
in order to be able to set the tiling direction faster and in the same way it is done in `i3wm`.
When using `toggle-tiling-direction` one always has to identify the current direction first.

Let me know what you think. Specially whether using `panic!` here is the right method:
https://github.com/JonasWischeropp/glazewm/blob/3c3fd07cd667c7e6165aa422d144e88ee0858af0/packages/wm/src/containers/commands/toggle_tiling_direction.rs#L110


Thank you for this amazing window manager.