### PR TITLE
feat: add new config `general.shutdown_commands` and `general.reload_commands` and shutdown/reload Zebar along side the WM

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ general:
   # Commands to run when the WM has started (e.g. to run a script or launch
   # another application).
   startup_commands: []
+  # Commands to run just before the WM is shutdown.
+  shutdown_commands : []
+  # Commands to run after the WM config has reloaded.
+  reload_commands: []
 
   # Whether to automatically focus windows underneath the cursor.
   focus_follows_cursor: false

--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ general:
   # Commands to run when the WM has started (e.g. to run a script or launch
   # another application).
   startup_commands: []
+
   # Commands to run just before the WM is shutdown.
   shutdown_commands : []
+
   # Commands to run after the WM config has reloaded.
-  reload_commands: []
+  config_reload_commands: []
 
   # Whether to automatically focus windows underneath the cursor.
   focus_follows_cursor: false

--- a/packages/watcher/src/main.rs
+++ b/packages/watcher/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
   match subscribe_res {
     Ok(_) => info!("WM exited successfully. Skipping watcher cleanup."),
     Err(err) => {
-      info!("Running watcher cleanup. WM exitted unexpectedly: {}", err);
+      info!("Running watcher cleanup. WM exited unexpectedly: {}", err);
 
       let managed_windows = managed_handles
         .into_iter()

--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -641,27 +641,30 @@ impl InvokeCommand {
 
   pub fn run_multiple(
     commands: Vec<InvokeCommand>,
-    container: Container,
+    subject_container: Container,
     state: &mut WmState,
     config: &mut UserConfig,
   ) -> anyhow::Result<Uuid> {
-    let mut subject_container = container;
+    let mut current_subject_container = subject_container;
 
     for command in commands {
-      command.run(subject_container.clone(), state, config)?;
+      command.run(current_subject_container.clone(), state, config)?;
 
       // Update the subject container in case the container type changes.
       // For example, when going from a tiling to a floating window.
-      subject_container = match subject_container.is_detached() {
-        false => subject_container,
-        true => match state.container_by_id(subject_container.id()) {
-          Some(container) => container,
-          None => break,
-        },
-      }
+      current_subject_container =
+        match current_subject_container.is_detached() {
+          false => current_subject_container,
+          true => {
+            match state.container_by_id(current_subject_container.id()) {
+              Some(container) => container,
+              None => break,
+            }
+          }
+        }
     }
 
-    Ok(subject_container.id())
+    Ok(current_subject_container.id())
   }
 }
 

--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -31,6 +31,7 @@ use crate::{
     traits::WindowGetters,
     WindowState,
   },
+  wm::perform_commands,
   wm_state::WmState,
   workspaces::{
     commands::{focus_workspace, move_workspace_in_direction},
@@ -604,6 +605,13 @@ impl InvokeCommand {
         enable_binding_mode(name, state, config)
       }
       InvokeCommand::WmExit => {
+        perform_commands(
+          config.value.general.shutdown_commands.clone(),
+          subject_container,
+          state,
+          config,
+        )?;
+
         state.emit_exit();
         Ok(())
       }
@@ -616,7 +624,17 @@ impl InvokeCommand {
 
         Ok(())
       }
-      InvokeCommand::WmReloadConfig => reload_config(state, config),
+      InvokeCommand::WmReloadConfig => {
+        reload_config(state, config)?;
+
+        perform_commands(
+          config.value.general.reload_commands.clone(),
+          subject_container,
+          state,
+          config,
+        )?;
+        Ok(())
+      }
     }
   }
 }

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -395,6 +395,14 @@ pub struct GeneralConfig {
   /// launch another application).
   #[serde(default)]
   pub startup_commands: Vec<InvokeCommand>,
+
+  /// Commands to run just before the WM is shutdown.
+  #[serde(default)]
+  pub shutdown_commands: Vec<InvokeCommand>,
+
+  /// Commands to run after the WM config has reloaded.
+  #[serde(default)]
+  pub reload_commands: Vec<InvokeCommand>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -402,7 +402,7 @@ pub struct GeneralConfig {
 
   /// Commands to run after the WM config has reloaded.
   #[serde(default)]
-  pub reload_commands: Vec<InvokeCommand>,
+  pub config_reload_commands: Vec<InvokeCommand>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -118,7 +118,7 @@ impl WindowManager {
         .context("No subject container for command.")?,
     };
 
-    let subject_container_id = InvokeCommand::run_multiple(
+    let new_subject_container_id = InvokeCommand::run_multiple(
       commands,
       subject_container,
       state,
@@ -126,6 +126,6 @@ impl WindowManager {
     )?;
     platform_sync(state, config)?;
 
-    Ok(subject_container_id)
+    Ok(new_subject_container_id)
   }
 }

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -129,21 +129,21 @@ pub fn perform_commands(
   state: &mut WmState,
   config: &mut UserConfig,
 ) -> anyhow::Result<Uuid> {
-    for command in commands {
-      command.run(subject_container.clone(), state, config)?;
+  for command in commands {
+    command.run(subject_container.clone(), state, config)?;
 
-      // Update the subject container in case the container type changes.
-      // For example, when going from a tiling to a floating window.
-      subject_container = match subject_container.is_detached() {
-        false => subject_container,
-        true => match state.container_by_id(subject_container.id()) {
-          Some(container) => container,
-          None => break,
-        },
-      }
+    // Update the subject container in case the container type changes.
+    // For example, when going from a tiling to a floating window.
+    subject_container = match subject_container.is_detached() {
+      false => subject_container,
+      true => match state.container_by_id(subject_container.id()) {
+        Some(container) => container,
+        None => break,
+      },
     }
+  }
 
-    platform_sync(state, config)?;
+  platform_sync(state, config)?;
 
-    Ok(subject_container.id())
+  Ok(subject_container.id())
 }

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -17,7 +17,6 @@ use crate::{
     },
     platform::PlatformEvent,
   },
-  containers::{traits::CommonGetters, Container},
   user_config::UserConfig,
   wm_event::WmEvent,
   wm_state::WmState,
@@ -119,31 +118,14 @@ impl WindowManager {
         .context("No subject container for command.")?,
     };
 
-    perform_commands(commands, subject_container, state, config)
+    let subject_container_id = InvokeCommand::run_multiple(
+      commands,
+      subject_container,
+      state,
+      config,
+    )?;
+    platform_sync(state, config)?;
+
+    Ok(subject_container_id)
   }
-}
-
-pub fn perform_commands(
-  commands: Vec<InvokeCommand>,
-  mut subject_container: Container,
-  state: &mut WmState,
-  config: &mut UserConfig,
-) -> anyhow::Result<Uuid> {
-  for command in commands {
-    command.run(subject_container.clone(), state, config)?;
-
-    // Update the subject container in case the container type changes.
-    // For example, when going from a tiling to a floating window.
-    subject_container = match subject_container.is_detached() {
-      false => subject_container,
-      true => match state.container_by_id(subject_container.id()) {
-        Some(container) => container,
-        None => break,
-      },
-    }
-  }
-
-  platform_sync(state, config)?;
-
-  Ok(subject_container.id())
 }

--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -2,6 +2,16 @@ general:
   # Commands to run when the WM has started (e.g. to run a script or launch
   # another application). Here we are running a batch script to start Zebar.
   startup_commands: ['shell-exec %userprofile%/.glzr/zebar/start.bat']
+  # Similarly commands can be executed just before the WM is shutdown
+  # and after the config has reloaded.
+  # Here we shutdown Zebar when the WM is shutdown.
+  shutdown_commands: ['shell-exec taskkill /IM zebar.exe /F']
+  # Here we restart Zebar to reload the Zebar config when reloading the
+  # WM config.
+  reload_commands: [
+    'shell-exec taskkill /IM zebar.exe /F',
+    'shell-exec %userprofile%/.glzr/zebar/start.bat'
+  ]
 
   # Whether to automatically focus windows underneath the cursor.
   focus_follows_cursor: false

--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -8,7 +8,7 @@ general:
   shutdown_commands: ['shell-exec taskkill /IM zebar.exe /F']
   # Here we restart Zebar to reload the Zebar config when reloading the
   # WM config.
-  reload_commands: [
+  config_reload_commands: [
     'shell-exec taskkill /IM zebar.exe /F',
     'shell-exec %userprofile%/.glzr/zebar/start.bat'
   ]


### PR DESCRIPTION
This PR addresses #650 and #646
I added two config entries that allow easy execution of commands at shutdown and restart similar to `general.startup_commands`.
|Config entry| Execution time|
|-|-|
| `general.shutdown_commands` | just before shutdown |
| `general.reload_commands` | after config has reloaded |

These are then used in the sample config to shutdown and reload Zebar.
```yaml
general:
  startup_commands: ['shell-exec %userprofile%/.glzr/zebar/start.bat']
  shutdown_commands: ['shell-exec taskkill /IM zebar.exe /F']
  reload_commands: [
    'shell-exec taskkill /IM zebar.exe /F',
    'shell-exec %userprofile%/.glzr/zebar/start.bat'
  ]
```
