### PR TITLE
style: fix formatting

### DIFF
--- a/packages/wm/src/containers/commands/toggle_tiling_direction.rs
+++ b/packages/wm/src/containers/commands/toggle_tiling_direction.rs
@@ -96,6 +96,6 @@ pub fn set_tiling_direction(
 
   match direction_container.tiling_direction() == tiling_direction {
     true => Ok(()),
-    false => toggle_tiling_direction(container, state, config)
+    false => toggle_tiling_direction(container, state, config),
   }
 }

--- a/packages/wm/src/monitors/commands/mod.rs
+++ b/packages/wm/src/monitors/commands/mod.rs
@@ -1,11 +1,11 @@
 mod add_monitor;
+mod focus_monitor;
 mod remove_monitor;
 mod sort_monitors;
 mod update_monitor;
-mod focus_monitor;
 
 pub use add_monitor::*;
+pub use focus_monitor::*;
 pub use remove_monitor::*;
 pub use sort_monitors::*;
 pub use update_monitor::*;
-pub use focus_monitor::*;

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs, env, path::PathBuf};
+use std::{collections::HashMap, env, fs, path::PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Just fixed the formatting in oder that the git workflow `Lint check` no longer fails.
