### PR TITLE
fix: shutdown and config reload commands get run from tray menu

### DIFF
--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -10,7 +10,7 @@ use crate::{
   common::{
     commands::{
       cycle_focus, disable_binding_mode, enable_binding_mode,
-      platform_sync, reload_config, shell_exec,
+      reload_config, shell_exec,
     },
     Direction, LengthValue, RectDelta, TilingDirection,
   },
@@ -604,14 +604,6 @@ impl InvokeCommand {
         enable_binding_mode(name, state, config)
       }
       InvokeCommand::WmExit => {
-        Self::run_multiple(
-          config.value.general.shutdown_commands.clone(),
-          subject_container,
-          state,
-          config,
-        )?;
-        platform_sync(state, config)?;
-
         state.emit_exit();
         Ok(())
       }
@@ -624,18 +616,7 @@ impl InvokeCommand {
 
         Ok(())
       }
-      InvokeCommand::WmReloadConfig => {
-        reload_config(state, config)?;
-
-        Self::run_multiple(
-          config.value.general.config_reload_commands.clone(),
-          subject_container,
-          state,
-          config,
-        )?;
-        platform_sync(state, config)?;
-        Ok(())
-      }
+      InvokeCommand::WmReloadConfig => reload_config(state, config),
     }
   }
 

--- a/packages/wm/src/common/commands/reload_config.rs
+++ b/packages/wm/src/common/commands/reload_config.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use tracing::{info, warn};
 
 use crate::{
+  app_command::InvokeCommand,
   containers::traits::{CommonGetters, TilingSizeGetters},
   user_config::{ParsedConfig, UserConfig, WindowRuleEvent},
   windows::{commands::run_window_rules, traits::WindowGetters},
@@ -54,6 +55,14 @@ pub fn reload_config(
     config_string: config.value_str.clone(),
     parsed_config: config.value.clone(),
   });
+
+  // Run config reload commands.
+  InvokeCommand::run_multiple(
+    config.value.general.config_reload_commands.clone(),
+    state.focused_container().context("No focused container.")?,
+    state,
+    config,
+  )?;
 
   Ok(())
 }

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -124,6 +124,7 @@ impl WindowManager {
       state,
       config,
     )?;
+
     platform_sync(state, config)?;
 
     Ok(new_subject_container_id)

--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -1,17 +1,15 @@
 general:
-  # Commands to run when the WM has started (e.g. to run a script or launch
-  # another application). Here we are running a batch script to start Zebar.
-  startup_commands: ['shell-exec %userprofile%/.glzr/zebar/start.bat']
-  # Similarly commands can be executed just before the WM is shutdown
-  # and after the config has reloaded.
-  # Here we shutdown Zebar when the WM is shutdown.
+  # Commands to run when the WM has started. This is useful for running a
+  # script or launching another application.
+  # Example: The below command launches Zebar.
+  startup_commands: ['shell-exec zebar']
+
+  # Commands to run just before the WM is shutdown.
+  # Example: The below command kills Zebar.
   shutdown_commands: ['shell-exec taskkill /IM zebar.exe /F']
-  # Here we restart Zebar to reload the Zebar config when reloading the
-  # WM config.
-  config_reload_commands: [
-    'shell-exec taskkill /IM zebar.exe /F',
-    'shell-exec %userprofile%/.glzr/zebar/start.bat'
-  ]
+
+  # Commands to run after the WM config is reloaded.
+  config_reload_commands: []
 
   # Whether to automatically focus windows underneath the cursor.
   focus_follows_cursor: false


### PR DESCRIPTION
* Ensure `shutdown_commands` and `config_reload_commands` are run when corresponding system tray options are clicked.
* Update Zebar launch via `startup_commands` to be compatible with Zebar v2.
* Zebar restart via `taskkill` doesn't seem to be working properly. Removing it for now until a reload CLI command is added natively.