### PR TITLE
ci: add separate winget release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,5 +64,5 @@ jobs:
         uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: glzr-io.glazewm
-          installers-regex: 'glazewm-[0-9.]+\.exe$'
+          installers-regex: '\.exe$' # Only .exe files
           token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,4 +65,5 @@ jobs:
         with:
           identifier: glzr-io.glazewm
           installers-regex: '\.exe$' # Only .exe files
+          version: ${{ github.event.release.tag_name }}
           token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,11 +59,3 @@ jobs:
                 "label": "${nextRelease.gitTag} Standalone Installer (arm64)"
               }
             ]
-
-      - name: Winget release
-        uses: vedantmgoyal9/winget-releaser@main
-        with:
-          identifier: glzr-io.glazewm
-          installers-regex: '\.exe$' # Only .exe files
-          version: ${{ github.event.release.tag_name }}
-          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget-release.yaml
+++ b/.github/workflows/winget-release.yaml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal2009/winget-releaser@main
         with:
           identifier: glzr-io.glazewm
           installers-regex: 'glazewm-[0-9.]+\.exe$'

--- a/.github/workflows/winget-release.yaml
+++ b/.github/workflows/winget-release.yaml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@main
+      - uses: vedantmgoyal2009/winget-releaser@b87a066d9e624db1394edcd947f8c4e5a7e30cd7
         with:
           identifier: glzr-io.glazewm
           installers-regex: 'glazewm-[0-9.]+\.exe$'

--- a/.github/workflows/winget-release.yaml
+++ b/.github/workflows/winget-release.yaml
@@ -1,7 +1,7 @@
 name: Winget Release
 on:
   release:
-    types: [released]
+    types: [published]
 
 jobs:
   publish:

--- a/.github/workflows/winget-release.yaml
+++ b/.github/workflows/winget-release.yaml
@@ -1,5 +1,6 @@
-name: Winget Release
+name: Winget release
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/winget-release.yaml
+++ b/.github/workflows/winget-release.yaml
@@ -1,0 +1,14 @@
+name: Winget Release
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: glzr-io.glazewm
+          installers-regex: 'glazewm-[0-9.]+\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Changed winget workflow to correctly run as intended during publish of new release