### PR TITLE
feat: scale inner and outer gaps by monitor DPI 

### DIFF
--- a/packages/wm/src/common/length_value.rs
+++ b/packages/wm/src/common/length_value.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{ops::Mul, str::FromStr};
 
 use anyhow::{bail, Context};
 use regex::Regex;
@@ -101,6 +101,16 @@ impl<'de> Deserialize<'de> for LengthValue {
       LengthValueDe::String(str) => {
         Self::from_str(&str).map_err(serde::de::Error::custom)
       }
+    }
+  }
+}
+
+impl Mul<f32> for LengthValue {
+  type Output = Self;
+  fn mul(self, rhs: f32) -> Self {
+    Self {
+      amount: self.amount * rhs,
+      unit: self.unit,
     }
   }
 }

--- a/packages/wm/src/common/length_value.rs
+++ b/packages/wm/src/common/length_value.rs
@@ -32,6 +32,13 @@ impl LengthValue {
     }
   }
 
+  pub fn to_px_scaled(&self, total_px: i32, scale_factor: f32) -> i32 {
+    match self.unit {
+      LengthUnit::Percentage => self.to_px(total_px),
+      LengthUnit::Pixel => (scale_factor * self.amount) as i32,
+    }
+  }
+
   pub fn to_percentage(&self, total_px: i32) -> f32 {
     match self.unit {
       LengthUnit::Percentage => self.amount,

--- a/packages/wm/src/common/rect_delta.rs
+++ b/packages/wm/src/common/rect_delta.rs
@@ -1,3 +1,5 @@
+use std::ops::Mul;
+
 use serde::{Deserialize, Serialize};
 
 use super::LengthValue;
@@ -30,5 +32,17 @@ impl RectDelta {
       right,
       bottom,
     }
+  }
+}
+
+impl Mul<f32> for RectDelta {
+  type Output = Self;
+  fn mul(self, rhs: f32) -> Self {
+    Self::new(
+      self.left * rhs,
+      self.top * rhs,
+      self.right * rhs,
+      self.bottom * rhs,
+    )
   }
 }

--- a/packages/wm/src/containers/traits/tiling_size_getters.rs
+++ b/packages/wm/src/containers/traits/tiling_size_getters.rs
@@ -77,7 +77,14 @@ macro_rules! impl_tiling_size_getters {
       }
 
       fn inner_gap(&self) -> LengthValue {
-        self.0.borrow().inner_gap.clone()
+        let scale = match self.monitor() {
+          None => 1_f32,
+          Some(monitor) => match monitor.native().dpi() {
+            Ok(dpi) => dpi,
+            Err(_) => 1_f32,
+          },
+        };
+        self.0.borrow().inner_gap.clone() * scale
       }
 
       fn set_inner_gap(&self, inner_gap: LengthValue) {

--- a/packages/wm/src/workspaces/workspace.rs
+++ b/packages/wm/src/workspaces/workspace.rs
@@ -139,7 +139,11 @@ impl PositionGetters for Workspace {
       .cloned()
       .context("Failed to get working area of parent monitor.")?;
 
-    let outer_gap = &self.0.borrow().outer_gap;
-    Ok(working_rect.apply_inverse_delta(outer_gap))
+    let scale = match self.monitor() {
+      None => 1_f32,
+      Some(monitor) => monitor.native().dpi()?,
+    };
+    let outer_gap = self.0.borrow().outer_gap.clone() * scale;
+    Ok(working_rect.apply_inverse_delta(&outer_gap))
   }
 }


### PR DESCRIPTION
I was trying to make my zebar config work with multiple monitors that have different display scaling factors.
Related discussion: glzr-io/zebar#72
This PR suggests a possible fix by scaling `outer_gap` and `inner_gap` by the display scale.
Let me know if I should change something.