### PR TITLE
feat: focus next/prev workspace by config order; add `—next-active-workspace` and `—prev-active-workspace`

### DIFF
--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -325,6 +325,14 @@ impl InvokeCommand {
           focus_workspace(WorkspaceTarget::Previous, state, config)?;
         }
 
+        if args.next_order_workspace {
+          focus_workspace(WorkspaceTarget::NextOrder, state, config)?;
+        }
+
+        if args.prev_order_workspace {
+          focus_workspace(WorkspaceTarget::PreviousOrder, state, config)?;
+        }
+
         if args.recent_workspace {
           focus_workspace(WorkspaceTarget::Recent, state, config)?;
         }
@@ -371,6 +379,24 @@ impl InvokeCommand {
               move_window_to_workspace(
                 window.clone(),
                 WorkspaceTarget::Previous,
+                state,
+                config,
+              )?;
+            }
+
+            if args.next_order_workspace {
+              move_window_to_workspace(
+                window.clone(),
+                WorkspaceTarget::NextOrder,
+                state,
+                config,
+              )?;
+            }
+
+            if args.prev_order_workspace {
+              move_window_to_workspace(
+                window.clone(),
+                WorkspaceTarget::PreviousOrder,
                 state,
                 config,
               )?;
@@ -730,6 +756,12 @@ pub struct InvokeFocusCommand {
   prev_workspace: bool,
 
   #[clap(long)]
+  next_order_workspace: bool,
+
+  #[clap(long)]
+  prev_order_workspace: bool,
+
+  #[clap(long)]
   recent_workspace: bool,
 }
 
@@ -749,6 +781,12 @@ pub struct InvokeMoveCommand {
 
   #[clap(long)]
   prev_workspace: bool,
+
+  #[clap(long)]
+  next_order_workspace: bool,
+
+  #[clap(long)]
+  prev_order_workspace: bool,
 
   #[clap(long)]
   recent_workspace: bool,

--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -317,20 +317,20 @@ impl InvokeCommand {
           focus_monitor(*monitor_index, state, config)?;
         }
 
+        if args.next_active_workspace {
+          focus_workspace(WorkspaceTarget::NextActive, state, config)?;
+        }
+
+        if args.prev_active_workspace {
+          focus_workspace(WorkspaceTarget::PreviousActive, state, config)?;
+        }
+
         if args.next_workspace {
           focus_workspace(WorkspaceTarget::Next, state, config)?;
         }
 
         if args.prev_workspace {
           focus_workspace(WorkspaceTarget::Previous, state, config)?;
-        }
-
-        if args.next_order_workspace {
-          focus_workspace(WorkspaceTarget::NextOrder, state, config)?;
-        }
-
-        if args.prev_order_workspace {
-          focus_workspace(WorkspaceTarget::PreviousOrder, state, config)?;
         }
 
         if args.recent_workspace {
@@ -366,6 +366,24 @@ impl InvokeCommand {
               )?;
             }
 
+            if args.next_active_workspace {
+              move_window_to_workspace(
+                window.clone(),
+                WorkspaceTarget::NextActive,
+                state,
+                config,
+              )?;
+            }
+
+            if args.prev_active_workspace {
+              move_window_to_workspace(
+                window.clone(),
+                WorkspaceTarget::PreviousActive,
+                state,
+                config,
+              )?;
+            }
+
             if args.next_workspace {
               move_window_to_workspace(
                 window.clone(),
@@ -379,24 +397,6 @@ impl InvokeCommand {
               move_window_to_workspace(
                 window.clone(),
                 WorkspaceTarget::Previous,
-                state,
-                config,
-              )?;
-            }
-
-            if args.next_order_workspace {
-              move_window_to_workspace(
-                window.clone(),
-                WorkspaceTarget::NextOrder,
-                state,
-                config,
-              )?;
-            }
-
-            if args.prev_order_workspace {
-              move_window_to_workspace(
-                window.clone(),
-                WorkspaceTarget::PreviousOrder,
                 state,
                 config,
               )?;
@@ -750,16 +750,16 @@ pub struct InvokeFocusCommand {
   monitor: Option<usize>,
 
   #[clap(long)]
+  next_active_workspace: bool,
+
+  #[clap(long)]
+  prev_active_workspace: bool,
+
+  #[clap(long)]
   next_workspace: bool,
 
   #[clap(long)]
   prev_workspace: bool,
-
-  #[clap(long)]
-  next_order_workspace: bool,
-
-  #[clap(long)]
-  prev_order_workspace: bool,
 
   #[clap(long)]
   recent_workspace: bool,
@@ -777,16 +777,16 @@ pub struct InvokeMoveCommand {
   workspace: Option<String>,
 
   #[clap(long)]
+  next_active_workspace: bool,
+
+  #[clap(long)]
+  prev_active_workspace: bool,
+
+  #[clap(long)]
   next_workspace: bool,
 
   #[clap(long)]
   prev_workspace: bool,
-
-  #[clap(long)]
-  next_order_workspace: bool,
-
-  #[clap(long)]
-  prev_order_workspace: bool,
 
   #[clap(long)]
   recent_workspace: bool,

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -302,7 +302,7 @@ impl WmState {
           .as_ref()
           .and_then(|name| self.workspace_by_name(&name)),
       ),
-      WorkspaceTarget::Next => {
+      WorkspaceTarget::NextActive => {
         let workspaces = self.sorted_workspaces(config);
         let origin_index = workspaces
           .iter()
@@ -318,7 +318,7 @@ impl WmState {
           next_workspace.cloned(),
         )
       }
-      WorkspaceTarget::Previous => {
+      WorkspaceTarget::PreviousActive => {
         let workspaces = self.sorted_workspaces(config);
         let origin_index = workspaces
           .iter()
@@ -334,7 +334,27 @@ impl WmState {
           prev_workspace.cloned(),
         )
       }
-      WorkspaceTarget::PreviousOrder => {
+      WorkspaceTarget::Next => {
+        let workspaces = &config.value.workspaces; 
+        let origin_name = origin_workspace.config().name.clone();
+        let origin_index = workspaces.iter()
+            .position(|workspace| workspace.name == origin_name)
+            .unwrap_or_else(|| workspaces.len()); 
+    
+        let next_workspace_config = if origin_index < workspaces.len() - 1 {
+            workspaces.get(origin_index + 1)
+        } else {
+            workspaces.first()
+        };
+      
+        let next_workspace_name = next_workspace_config.map(|config| config.name.clone());
+        let next_workspace = next_workspace_name
+            .as_ref()
+            .and_then(|name| self.workspace_by_name(name));
+      
+        (next_workspace_name, next_workspace)
+      }
+      WorkspaceTarget::Previous => {
         let workspaces = &config.value.workspaces; 
         let origin_name = origin_workspace.config().name.clone();
         let origin_index = workspaces.iter()
@@ -355,26 +375,6 @@ impl WmState {
         (previous_workspace_name, previous_workspace)
       }
     
-      WorkspaceTarget::NextOrder => {
-          let workspaces = &config.value.workspaces; 
-          let origin_name = origin_workspace.config().name.clone();
-          let origin_index = workspaces.iter()
-              .position(|workspace| workspace.name == origin_name)
-              .unwrap_or_else(|| workspaces.len()); 
-      
-          let next_workspace_config = if origin_index < workspaces.len() - 1 {
-              workspaces.get(origin_index + 1)
-          } else {
-              workspaces.first()
-          };
-        
-          let next_workspace_name = next_workspace_config.map(|config| config.name.clone());
-          let next_workspace = next_workspace_name
-              .as_ref()
-              .and_then(|name| self.workspace_by_name(name));
-        
-          (next_workspace_name, next_workspace)
-      }
       WorkspaceTarget::Direction(direction) => {
         let origin_monitor =
           origin_workspace.monitor().context("No focused monitor.")?;

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -339,7 +339,7 @@ impl WmState {
         let origin_name = origin_workspace.config().name.clone();
         let origin_index = workspaces.iter()
             .position(|workspace| workspace.name == origin_name)
-            .unwrap_or_else(|| workspaces.len()); 
+            .context("Failed to get index of given workspace.")?;
     
         let next_workspace_config = if origin_index < workspaces.len() - 1 {
             workspaces.get(origin_index + 1)
@@ -359,7 +359,7 @@ impl WmState {
         let origin_name = origin_workspace.config().name.clone();
         let origin_index = workspaces.iter()
             .position(|workspace| workspace.name == origin_name)
-            .unwrap_or_else(|| workspaces.len()); 
+            .context("Failed to get index of given workspace.")?;
     
         let previous_workspace_config = if origin_index > 0 {
             workspaces.get(origin_index - 1)

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -341,11 +341,9 @@ impl WmState {
             .position(|workspace| workspace.name == origin_name)
             .context("Failed to get index of given workspace.")?;
     
-        let next_workspace_config = if origin_index < workspaces.len() - 1 {
-            workspaces.get(origin_index + 1)
-        } else {
-            workspaces.first()
-        };
+        let next_workspace_config = workspaces
+            .get(origin_index + 1)
+            .or_else(|| workspaces.first());
       
         let next_workspace_name = next_workspace_config.map(|config| config.name.clone());
         let next_workspace = next_workspace_name
@@ -361,11 +359,9 @@ impl WmState {
             .position(|workspace| workspace.name == origin_name)
             .context("Failed to get index of given workspace.")?;
     
-        let previous_workspace_config = if origin_index > 0 {
-            workspaces.get(origin_index - 1)
-        } else {
-            workspaces.last()
-        };
+        let previous_workspace_config = workspaces.get(
+              origin_index.checked_sub(1).unwrap_or(workspaces.len() - 1),
+            );
     
         let previous_workspace_name = previous_workspace_config.map(|config| config.name.clone());
         let previous_workspace = previous_workspace_name

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -334,6 +334,47 @@ impl WmState {
           prev_workspace.cloned(),
         )
       }
+      WorkspaceTarget::PreviousOrder => {
+        let workspaces = &config.value.workspaces; 
+        let origin_name = origin_workspace.config().name.clone();
+        let origin_index = workspaces.iter()
+            .position(|workspace| workspace.name == origin_name)
+            .unwrap_or_else(|| workspaces.len()); 
+    
+        let previous_workspace_config = if origin_index > 0 {
+            workspaces.get(origin_index - 1)
+        } else {
+            workspaces.last()
+        };
+    
+        let previous_workspace_name = previous_workspace_config.map(|config| config.name.clone());
+        let previous_workspace = previous_workspace_name
+            .as_ref()
+            .and_then(|name| self.workspace_by_name(name));
+    
+        (previous_workspace_name, previous_workspace)
+      }
+    
+      WorkspaceTarget::NextOrder => {
+          let workspaces = &config.value.workspaces; 
+          let origin_name = origin_workspace.config().name.clone();
+          let origin_index = workspaces.iter()
+              .position(|workspace| workspace.name == origin_name)
+              .unwrap_or_else(|| workspaces.len()); 
+      
+          let next_workspace_config = if origin_index < workspaces.len() - 1 {
+              workspaces.get(origin_index + 1)
+          } else {
+              workspaces.first()
+          };
+        
+          let next_workspace_name = next_workspace_config.map(|config| config.name.clone());
+          let next_workspace = next_workspace_name
+              .as_ref()
+              .and_then(|name| self.workspace_by_name(name));
+        
+          (next_workspace_name, next_workspace)
+      }
       WorkspaceTarget::Direction(direction) => {
         let origin_monitor =
           origin_workspace.monitor().context("No focused monitor.")?;

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -303,35 +303,35 @@ impl WmState {
           .and_then(|name| self.workspace_by_name(&name)),
       ),
       WorkspaceTarget::NextActive => {
-        let workspaces = self.sorted_workspaces(config);
-        let origin_index = workspaces
+        let active_workspaces = self.sorted_workspaces(config);
+        let origin_index = active_workspaces
           .iter()
           .position(|workspace| workspace.id() == origin_workspace.id())
           .context("Failed to get index of given workspace.")?;
 
-        let next_workspace = workspaces
+        let next_active_workspace = active_workspaces
           .get(origin_index + 1)
-          .or_else(|| workspaces.first());
+          .or_else(|| active_workspaces.first());
 
         (
-          next_workspace.map(|workspace| workspace.config().name),
-          next_workspace.cloned(),
+          next_active_workspace.map(|workspace| workspace.config().name),
+          next_active_workspace.cloned(),
         )
       }
       WorkspaceTarget::PreviousActive => {
-        let workspaces = self.sorted_workspaces(config);
-        let origin_index = workspaces
+        let active_workspaces = self.sorted_workspaces(config);
+        let origin_index = active_workspaces
           .iter()
           .position(|workspace| workspace.id() == origin_workspace.id())
           .context("Failed to get index of given workspace.")?;
 
-        let prev_workspace = workspaces.get(
-          origin_index.checked_sub(1).unwrap_or(workspaces.len() - 1),
+        let prev_active_workspace = active_workspaces.get(
+          origin_index.checked_sub(1).unwrap_or(active_workspaces.len() - 1),
         );
 
         (
-          prev_workspace.map(|workspace| workspace.config().name),
-          prev_workspace.cloned(),
+          prev_active_workspace.map(|workspace| workspace.config().name),
+          prev_active_workspace.cloned(),
         )
       }
       WorkspaceTarget::Next => {

--- a/packages/wm/src/workspaces/workspace_target.rs
+++ b/packages/wm/src/workspaces/workspace_target.rs
@@ -3,9 +3,9 @@ use crate::common::Direction;
 pub enum WorkspaceTarget {
   Name(String),
   Recent,
+  NextActive,
+  PreviousActive,
   Next,
   Previous,
-  NextOrder,
-  PreviousOrder,
   Direction(Direction),
 }

--- a/packages/wm/src/workspaces/workspace_target.rs
+++ b/packages/wm/src/workspaces/workspace_target.rs
@@ -5,5 +5,7 @@ pub enum WorkspaceTarget {
   Recent,
   Next,
   Previous,
+  NextOrder,
+  PreviousOrder,
   Direction(Direction),
 }


### PR DESCRIPTION
close https://github.com/glzr-io/glazewm/issues/715

usage:
```
  - commands: ["focus --next-workspace"] 
    bindings: ["Lwin+Right"]
  - commands: ["focus --prev-workspace"] 
    bindings: ["Lwin+Left"]

  - commands: ["focus --next-active-workspace"] 
    bindings: ["Lwin+Right"]
  - commands: ["focus --prev-acitve-workspace"] 
    bindings: ["Lwin+Left"]

```