### PR TITLE
fix: prevent focus requests from being lost from windows on inactive workspaces

### DIFF
--- a/packages/wm/src/common/events/handle_window_focused.rs
+++ b/packages/wm/src/common/events/handle_window_focused.rs
@@ -24,10 +24,8 @@ pub fn handle_window_focused(
     // Ignore the focus event if:
     // 1. Window is being hidden by the WM.
     // 2. Focus is already set to the WM's focused container.
-    // 3. Window is not actually the foreground window.
     if window.display_state() == DisplayState::Hiding
       || state.focused_container() == Some(window.clone().into())
-      || Platform::foreground_window() != native_window
     {
       return Ok(());
     }


### PR DESCRIPTION
close: https://github.com/glzr-io/glazewm/issues/780


refer to:
https://discord.com/channels/1041662798196908052/1041678923878125589/1296640722035802133
