### PR TITLE
feat: add `not_equals` and `not_regex` match types

### DIFF
--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -596,9 +596,9 @@ pub struct WindowMatchConfig {
 pub enum MatchType {
   Equals { equals: String },
   Includes { includes: String },
-  Regex { regex: String},
+  Regex { regex: String },
   NotEquals { not_equals: String },
-  NotRegex {not_regex: String}
+  NotRegex { not_regex: String },
 }
 
 impl MatchType {
@@ -607,13 +607,13 @@ impl MatchType {
     match self {
       MatchType::Equals { equals } => value == equals,
       MatchType::Includes { includes } => value.contains(includes),
-      MatchType::Regex { regex} => regex::Regex::new(regex)
-          .map(|re| re.is_match(value))
-          .unwrap_or(false),
+      MatchType::Regex { regex } => regex::Regex::new(regex)
+        .map(|re| re.is_match(value))
+        .unwrap_or(false),
       MatchType::NotEquals { not_equals } => value != not_equals,
       MatchType::NotRegex { not_regex } => regex::Regex::new(not_regex)
-          .map(|re| !re.is_match(value))
-          .unwrap_or(false),
+        .map(|re| !re.is_match(value))
+        .unwrap_or(false),
     }
   }
 }

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -596,8 +596,9 @@ pub struct WindowMatchConfig {
 pub enum MatchType {
   Equals { equals: String },
   Includes { includes: String },
-  Regex { regex: String, not: Option<bool> },
+  Regex { regex: String},
   NotEquals { not_equals: String },
+  NotRegex {not_regex: String}
 }
 
 impl MatchType {
@@ -606,17 +607,13 @@ impl MatchType {
     match self {
       MatchType::Equals { equals } => value == equals,
       MatchType::Includes { includes } => value.contains(includes),
-      MatchType::Regex { regex,not } => regex::Regex::new(regex)
-          .map(|re| {
-            let is_match = re.is_match(value);
-            match not {
-              Some(true) => !is_match,  // Negate the result if `not` is `Some(true)`
-              Some(false) => is_match,  // Use the result if `not` is `Some(false)`
-              None => is_match,         // Default to regular matching if `not` is `None`
-            }
-          })
+      MatchType::Regex { regex} => regex::Regex::new(regex)
+          .map(|re| re.is_match(value))
           .unwrap_or(false),
       MatchType::NotEquals { not_equals } => value != not_equals,
+      MatchType::NotRegex { not_regex } => regex::Regex::new(not_regex)
+          .map(|re| !re.is_match(value))
+          .unwrap_or(false),
     }
   }
 }

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -326,7 +326,9 @@ impl WmState {
           .context("Failed to get index of given workspace.")?;
 
         let prev_active_workspace = active_workspaces.get(
-          origin_index.checked_sub(1).unwrap_or(active_workspaces.len() - 1),
+          origin_index
+            .checked_sub(1)
+            .unwrap_or(active_workspaces.len() - 1),
         );
 
         (
@@ -335,42 +337,48 @@ impl WmState {
         )
       }
       WorkspaceTarget::Next => {
-        let workspaces = &config.value.workspaces; 
+        let workspaces = &config.value.workspaces;
         let origin_name = origin_workspace.config().name.clone();
-        let origin_index = workspaces.iter()
-            .position(|workspace| workspace.name == origin_name)
-            .context("Failed to get index of given workspace.")?;
-    
+        let origin_index = workspaces
+          .iter()
+          .position(|workspace| workspace.name == origin_name)
+          .context("Failed to get index of given workspace.")?;
+
         let next_workspace_config = workspaces
-            .get(origin_index + 1)
-            .or_else(|| workspaces.first());
-      
-        let next_workspace_name = next_workspace_config.map(|config| config.name.clone());
+          .get(origin_index + 1)
+          .or_else(|| workspaces.first());
+
+        let next_workspace_name =
+          next_workspace_config.map(|config| config.name.clone());
+
         let next_workspace = next_workspace_name
-            .as_ref()
-            .and_then(|name| self.workspace_by_name(name));
-      
+          .as_ref()
+          .and_then(|name| self.workspace_by_name(name));
+
         (next_workspace_name, next_workspace)
       }
       WorkspaceTarget::Previous => {
-        let workspaces = &config.value.workspaces; 
+        let workspaces = &config.value.workspaces;
         let origin_name = origin_workspace.config().name.clone();
-        let origin_index = workspaces.iter()
-            .position(|workspace| workspace.name == origin_name)
-            .context("Failed to get index of given workspace.")?;
-    
+        let origin_index = workspaces
+          .iter()
+          .position(|workspace| workspace.name == origin_name)
+          .context("Failed to get index of given workspace.")?;
+
         let previous_workspace_config = workspaces.get(
-              origin_index.checked_sub(1).unwrap_or(workspaces.len() - 1),
-            );
-    
-        let previous_workspace_name = previous_workspace_config.map(|config| config.name.clone());
+          origin_index.checked_sub(1).unwrap_or(workspaces.len() - 1),
+        );
+
+        let previous_workspace_name =
+          previous_workspace_config.map(|config| config.name.clone());
+
         let previous_workspace = previous_workspace_name
-            .as_ref()
-            .and_then(|name| self.workspace_by_name(name));
-    
+          .as_ref()
+          .and_then(|name| self.workspace_by_name(name));
+
         (previous_workspace_name, previous_workspace)
       }
-    
+
       WorkspaceTarget::Direction(direction) => {
         let origin_monitor =
           origin_workspace.monitor().context("No focused monitor.")?;


### PR DESCRIPTION
To @rpop0  "complaints" I added **not equals** for matchtype.

- Added a new match type: NotEquals, which checks for inequality.
- Extended the Regex match type to support an optional `not` parameter for negating regex matches.

An example of use would be for steam, you want the friend list and the chat to be ignored.
- window_title for friends list is Friends
- window_title for a chat is the person's name.
Normally you can use the regex method ^(?:(?!Steam).*$ but rust does not have support for Negative Lookahead.

Exemple of ussage:
- Not Equals:
```
- window_process: { equals: "steamwebhelper" }
  window_title: { not_equals: "Steam" }
```
-Not Regex
```
- window_process: { equals: "steamwebhelper" }
  window_title: { regex: "Steam", not: true }
```

At the same time, it fixes #786.