### PR TITLE
feat: automatically deactivate non-current workspaces when all window…

### DIFF
--- a/packages/wm/src/common/events/handle_window_destroyed.rs
+++ b/packages/wm/src/common/events/handle_window_destroyed.rs
@@ -1,8 +1,10 @@
 use tracing::info;
 
 use crate::{
-  common::platform::NativeWindow, windows::commands::unmanage_window,
+  common::platform::NativeWindow, windows::commands::unmanage_window, 
   wm_state::WmState,
+  containers::traits::CommonGetters,
+  workspaces::commands::deactivate_workspace
 };
 
 pub fn handle_window_destroyed(
@@ -14,8 +16,16 @@ pub fn handle_window_destroyed(
   // Unmanage the window if it's currently managed.
   if let Some(window) = found_window {
     // TODO: Log window details.
+    let bind_workspace = window.workspace();
+
     info!("Window closed");
     unmanage_window(window, state)?;
+
+    if let Some(workspace) = bind_workspace {
+      if !workspace.config().keep_alive && !workspace.has_children() && !workspace.is_displayed() {
+        deactivate_workspace(workspace, state)?;
+      }
+    }
   }
 
   Ok(())

--- a/packages/wm/src/common/events/handle_window_destroyed.rs
+++ b/packages/wm/src/common/events/handle_window_destroyed.rs
@@ -1,7 +1,7 @@
 use tracing::info;
 
 use crate::{
-  common::platform::NativeWindow, windows::commands::unmanage_window, 
+  common::platform::NativeWindow, windows::commands::unmanage_window,
   wm_state::WmState,
   containers::traits::CommonGetters,
   workspaces::commands::deactivate_workspace


### PR DESCRIPTION
Its feature is that when all Windows in a workspace (not necessarily the current one) are destroyed and that workspace is not currently being dispalyed, that workspace will also be automatically deactivate, making it more efficient to focus on the active workspace without having to focus on the windowless workspace again to deactivate it

https://github.com/user-attachments/assets/2a05b460-4cf1-4314-a03b-e906d0a0217c

