### PR TITLE
docs: fix link to "Config documentation" heading in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GlazeWM lets you easily organize windows and adjust their layout on the fly by u
 
 [Installation](#installation) •
 [Default keybindings](#default-keybindings) •
-[Config documentation](#config-docs) •
+[Config documentation](#config-documentation) •
 [FAQ](#faq) •
 [Contributing ↗](https://github.com/glzr-io/glazewm/blob/main/CONTRIBUTING.md)
 


### PR DESCRIPTION
Fix the config documentation link in readme
<!--
Before submitting a PR, follow this checklist:

1. Give the PR a descriptive title.

  Examples of good titles:
    - fix: fix race condition in message loop
    - docs: update readme with new demo gif
    - feat: add new `general.focus_follows_mouse` config option

  Examples of bad titles:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR description, e.g. closes #123.
3. Propose your changes as a draft PR if your work is still in progress.
-->
