### PR TITLE
feat: add new `position` command; allow size and position to be set with `set-floating` command

### DIFF
--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -443,19 +443,14 @@ impl InvokeCommand {
       }
       InvokeCommand::Position(args) => {
         match subject_container.as_window_container() {
-          Ok(window) => {
-            match args.centered {
-              true => set_window_position_to_center(window, state),
-              false => {
-                set_window_position(
-                  window,
-                  args.x_pos.clone(),
-                  args.y_pos.clone(),
-                  state,
-                )
-              }
-            }
-
+          Ok(window) => match args.centered {
+            true => set_window_position_to_center(window, state),
+            false => set_window_position(
+              window,
+              args.x_pos.clone(),
+              args.y_pos.clone(),
+              state,
+            ),
           },
           _ => Ok(()),
         }
@@ -482,8 +477,7 @@ impl InvokeCommand {
         Ok(window) => {
           let floating_defaults =
             &config.value.window_behavior.state_defaults.floating;
-          let is_centered = 
-            centered.unwrap_or(floating_defaults.centered);
+          let is_centered = centered.unwrap_or(floating_defaults.centered);
 
           let window = update_window_state(
             window.clone(),
@@ -509,11 +503,11 @@ impl InvokeCommand {
             set_window_position_to_center(window, state)?;
           } else if x_pos.is_some() || y_pos.is_some() {
             set_window_position(
-              window.clone(), 
+              window.clone(),
               x_pos.clone(),
-              y_pos.clone(), 
+              y_pos.clone(),
               state,
-            )?;                
+            )?;
           }
 
           Ok(())

--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -3,7 +3,6 @@ use std::{iter, path::PathBuf};
 use anyhow::{bail, Context};
 use clap::{error::KindFormatter, Args, Parser, ValueEnum};
 use serde::{Deserialize, Deserializer, Serialize};
-use tokio::net::windows;
 use tracing::{warn, Level};
 use uuid::Uuid;
 
@@ -12,13 +11,14 @@ use crate::{
     commands::{
       cycle_focus, disable_binding_mode, enable_binding_mode,
       reload_config, shell_exec,
-    }, Direction, LengthValue, Rect, RectDelta, TilingDirection
+    },
+    Direction, LengthValue, RectDelta, TilingDirection,
   },
   containers::{
     commands::{
       focus_in_direction, set_tiling_direction, toggle_tiling_direction,
     },
-    traits::{CommonGetters, PositionGetters},
+    traits::CommonGetters,
     Container,
   },
   monitors::commands::focus_monitor,
@@ -476,6 +476,17 @@ impl InvokeCommand {
           let is_centered = 
             centered.unwrap_or(floating_defaults.centered);
 
+          let window = update_window_state(
+            window.clone(),
+            WindowState::Floating(FloatingStateConfig {
+              centered: is_centered,
+              shown_on_top: shown_on_top
+                .unwrap_or(floating_defaults.shown_on_top),
+            }),
+            state,
+            config,
+          )?;
+
           if width.is_some() || height.is_some() {
             set_window_size(window.clone(),
             width.clone(),
@@ -490,17 +501,6 @@ impl InvokeCommand {
             x_pos.clone(),
             y_pos.clone(), state)?;  
           }
-              
-          update_window_state(
-            window.clone(),
-            WindowState::Floating(FloatingStateConfig {
-              centered: is_centered,
-              shown_on_top: shown_on_top
-                .unwrap_or(floating_defaults.shown_on_top),
-            }),
-            state,
-            config,
-          )?;
 
           Ok(())
         }

--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -197,6 +197,12 @@ pub enum InvokeCommand {
     centered: Option<bool>,
 
     #[clap(long, require_equals = true)]
+    xpos: Option<i32>,
+
+    #[clap(long, require_equals = true)]
+    ypos: Option<i32>,
+
+    #[clap(long, require_equals = true)]
     width: Option<i32>,
 
     #[clap(long, require_equals = true)]
@@ -447,6 +453,8 @@ impl InvokeCommand {
       InvokeCommand::SetFloating {
         centered,
         shown_on_top,
+        xpos,
+        ypos,
         width,
         height,
       } => match subject_container.as_window_container() {
@@ -457,9 +465,20 @@ impl InvokeCommand {
           let is_centered = centered.unwrap_or(floating_defaults.centered);
           let mut floating_placement = window.floating_placement().clone();
 
-          if let (Some(width), Some(height)) = (width, height) {
+          if let Some(xpos) = xpos {
+            floating_placement.left = xpos.clone();
+          }
+
+          if let Some(ypos) = ypos {
+            floating_placement.top = ypos.clone();
+          }
+
+          if let Some(width) = width {
             floating_placement.right = floating_placement.left + width;
-            floating_placement.bottom = floating_placement.top + height;
+          }
+        
+          if let Some(height) = height {
+              floating_placement.bottom = floating_placement.top + height;
           }
 
           if is_centered {
@@ -469,7 +488,7 @@ impl InvokeCommand {
               floating_placement
                 .translate_to_center(&workspace.to_rect()?),
             )
-          } else if width.is_some() && height.is_some() {
+          } else if xpos.is_some() || ypos.is_some() || width.is_some() || height.is_some() {
             window.set_floating_placement(floating_placement);
           }
 

--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -467,10 +467,22 @@ impl InvokeCommand {
           let floating_placement = window.floating_placement().clone();
 
           let window_rect = Rect::from_ltrb(
-            x_pos.clone().and_then(|rect_x| Some(rect_x.to_px(monitor_rect.x(), None))).unwrap_or_else(|| floating_placement.x()),
-            y_pos.clone().and_then(|rect_y| Some(rect_y.to_px(monitor_rect.y(), None))).unwrap_or_else(|| floating_placement.y()),
-            width.clone().and_then(|rect_width| Some(rect_width.to_px(monitor_rect.width(), None)+floating_placement.x())).unwrap_or_else(|| floating_placement.width()),
-            height.clone().and_then(|rect_height| Some(rect_height.to_px(monitor_rect.height(), None)+floating_placement.y())).unwrap_or_else(|| floating_placement.height()),
+            match x_pos {
+                Some(rect_x) => rect_x.to_px(monitor_rect.x(), None),
+                None => floating_placement.x(),
+            },
+            match y_pos {
+                Some(rect_y) => rect_y.to_px(monitor_rect.y(), None),
+                None => floating_placement.y(),
+            },
+            match width {
+                Some(rect_width) => rect_width.to_px(monitor_rect.width(), None) + floating_placement.x(),
+                None => floating_placement.width(),
+            },
+            match height {
+                Some(rect_height) => rect_height.to_px(monitor_rect.height(), None) + floating_placement.y(),
+                None => floating_placement.height(),
+            },
           );
           
           match is_centered {

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -118,6 +118,8 @@ impl UserConfig {
       commands: vec![InvokeCommand::SetFloating {
         centered: Some(floating_defaults.centered),
         shown_on_top: Some(floating_defaults.shown_on_top),
+        width: None,
+        height: None,
       }],
       match_window: vec![
         WindowMatchConfig {

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -118,8 +118,8 @@ impl UserConfig {
       commands: vec![InvokeCommand::SetFloating {
         centered: Some(floating_defaults.centered),
         shown_on_top: Some(floating_defaults.shown_on_top),
-        xpos: None,
-        ypos: None,
+        x_pos: None,
+        y_pos: None,
         width: None,
         height: None,
       }],

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -118,6 +118,8 @@ impl UserConfig {
       commands: vec![InvokeCommand::SetFloating {
         centered: Some(floating_defaults.centered),
         shown_on_top: Some(floating_defaults.shown_on_top),
+        xpos: None,
+        ypos: None,
         width: None,
         height: None,
       }],

--- a/packages/wm/src/windows/commands/mod.rs
+++ b/packages/wm/src/windows/commands/mod.rs
@@ -4,8 +4,8 @@ mod move_window_in_direction;
 mod move_window_to_workspace;
 mod resize_window;
 mod run_window_rules;
-mod set_window_size;
 mod set_window_position;
+mod set_window_size;
 mod unmanage_window;
 mod update_window_state;
 
@@ -15,7 +15,7 @@ pub use move_window_in_direction::*;
 pub use move_window_to_workspace::*;
 pub use resize_window::*;
 pub use run_window_rules::*;
-pub use set_window_size::*;
 pub use set_window_position::*;
+pub use set_window_size::*;
 pub use unmanage_window::*;
 pub use update_window_state::*;

--- a/packages/wm/src/windows/commands/mod.rs
+++ b/packages/wm/src/windows/commands/mod.rs
@@ -5,6 +5,7 @@ mod move_window_to_workspace;
 mod resize_window;
 mod run_window_rules;
 mod set_window_size;
+mod set_window_position;
 mod unmanage_window;
 mod update_window_state;
 
@@ -15,5 +16,6 @@ pub use move_window_to_workspace::*;
 pub use resize_window::*;
 pub use run_window_rules::*;
 pub use set_window_size::*;
+pub use set_window_position::*;
 pub use unmanage_window::*;
 pub use update_window_state::*;

--- a/packages/wm/src/windows/commands/set_window_position.rs
+++ b/packages/wm/src/windows/commands/set_window_position.rs
@@ -6,9 +6,7 @@ use crate::{
     traits::{CommonGetters, PositionGetters},
     WindowContainer,
   },
-  windows::{
-    traits::WindowGetters, WindowState,
-  },
+  windows::{traits::WindowGetters, WindowState},
   wm_state::WmState,
 };
 
@@ -28,7 +26,7 @@ pub fn set_window_position(
       window.floating_placement().width(),
       window.floating_placement().height(),
     ));
-  
+
     state
       .pending_sync
       .containers_to_redraw
@@ -44,17 +42,15 @@ pub fn set_window_position_to_center(
 ) -> anyhow::Result<()> {
   if matches!(window.state(), WindowState::Floating(_)) {
     let window_rect = window.floating_placement();
-      let workspace =
-      window.workspace().context("no workspace find.")?;
-      window.set_floating_placement(
-        window_rect
-        .translate_to_center(&workspace.to_rect()?),
-      );
+    let workspace = window.workspace().context("no workspace find.")?;
+    window.set_floating_placement(
+      window_rect.translate_to_center(&workspace.to_rect()?),
+    );
 
     state
-    .pending_sync
-    .containers_to_redraw
-    .push(window.clone().into());    
+      .pending_sync
+      .containers_to_redraw
+      .push(window.clone().into());
   }
 
   Ok(())

--- a/packages/wm/src/windows/commands/set_window_position.rs
+++ b/packages/wm/src/windows/commands/set_window_position.rs
@@ -1,87 +1,61 @@
 use anyhow::Context;
 
 use crate::{
-  common::{LengthValue, Rect},
+  common::Rect,
   containers::{
     traits::{CommonGetters, PositionGetters},
     WindowContainer,
   },
   windows::{
-    traits::WindowGetters, NonTilingWindow, WindowState,
+    traits::WindowGetters, WindowState,
   },
   wm_state::WmState,
 };
 
 pub fn set_window_position(
   window: WindowContainer,
-  centered: bool,
-  target_x_pos: Option<LengthValue>,
-  target_y_pos: Option<LengthValue>,
+  target_x_pos: Option<i32>,
+  target_y_pos: Option<i32>,
   state: &mut WmState,
 ) -> anyhow::Result<()> {
-  match window {
-    WindowContainer::TilingWindow(_) => {
-      return Ok(());
-    }
-    WindowContainer::NonTilingWindow(window) => {
-      if matches!(window.state(), WindowState::Floating(_)) {
-        set_floating_window_position(
-          window,
-          centered,
-          target_x_pos,
-          target_y_pos,
-          state,
-        )?;
-      }
-    }
+  if matches!(window.state(), WindowState::Floating(_)) {
+    let window_rect = window.floating_placement();
+    let new_x_pos = target_x_pos.unwrap_or(window_rect.x());
+    let new_y_pos = target_y_pos.unwrap_or(window_rect.y());
+    window.set_floating_placement(Rect::from_xy(
+      new_x_pos,
+      new_y_pos,
+      window.floating_placement().width(),
+      window.floating_placement().height(),
+    ));
+  
+    state
+      .pending_sync
+      .containers_to_redraw
+      .push(window.clone().into());
   }
 
   Ok(())
 }
 
-fn set_floating_window_position(
-  window: NonTilingWindow,
-  centered: bool,
-  target_x_pos: Option<LengthValue>,
-  target_y_pos: Option<LengthValue>,
+pub fn set_window_position_to_center(
+  window: WindowContainer,
   state: &mut WmState,
 ) -> anyhow::Result<()> {
-  let window_rect = window.floating_placement();
-
-  match centered {
-    true => {
+  if matches!(window.state(), WindowState::Floating(_)) {
+    let window_rect = window.floating_placement();
       let workspace =
       window.workspace().context("no workspace find.")?;
       window.set_floating_placement(
         window_rect
         .translate_to_center(&workspace.to_rect()?),
-      )         
-    },
-    false => {
-      let monitor = window.monitor().context("No monitor")?;
-      let monitor_rect = monitor.to_rect()?;
-    
-      let target_x_pos_px = target_x_pos
-      .map(|target_x_pos| target_x_pos.to_px(monitor_rect.x(), None));
-      let target_y_pos_px = target_y_pos
-      .map(|target_y_pos| target_y_pos.to_px(monitor_rect.y(), None));
-    
-      let new_x_pos = target_x_pos_px.unwrap_or(window_rect.x());
-      let new_y_pos = target_y_pos_px.unwrap_or(window_rect.y());
+      );
 
-      window.set_floating_placement(Rect::from_xy(
-        new_x_pos,
-        new_y_pos,
-        window.floating_placement().width(),
-        window.floating_placement().height(),
-      ));
-    }
-  }
-
-  state
+    state
     .pending_sync
     .containers_to_redraw
-    .push(window.clone().into());
+    .push(window.clone().into());    
+  }
 
   Ok(())
 }

--- a/packages/wm/src/windows/commands/set_window_position.rs
+++ b/packages/wm/src/windows/commands/set_window_position.rs
@@ -46,7 +46,7 @@ fn set_floating_window_position(
   target_y_pos: Option<LengthValue>,
   state: &mut WmState,
 ) -> anyhow::Result<()> {
-  let window_rect = window.to_rect()?;
+  let window_rect = window.floating_placement();
 
   match centered {
     true => {

--- a/packages/wm/src/windows/commands/set_window_position.rs
+++ b/packages/wm/src/windows/commands/set_window_position.rs
@@ -1,0 +1,87 @@
+use anyhow::Context;
+
+use crate::{
+  common::{LengthValue, Rect},
+  containers::{
+    traits::{CommonGetters, PositionGetters},
+    WindowContainer,
+  },
+  windows::{
+    traits::WindowGetters, NonTilingWindow, WindowState,
+  },
+  wm_state::WmState,
+};
+
+pub fn set_window_position(
+  window: WindowContainer,
+  centered: bool,
+  target_x_pos: Option<LengthValue>,
+  target_y_pos: Option<LengthValue>,
+  state: &mut WmState,
+) -> anyhow::Result<()> {
+  match window {
+    WindowContainer::TilingWindow(_) => {
+      return Ok(());
+    }
+    WindowContainer::NonTilingWindow(window) => {
+      if matches!(window.state(), WindowState::Floating(_)) {
+        set_floating_window_position(
+          window,
+          centered,
+          target_x_pos,
+          target_y_pos,
+          state,
+        )?;
+      }
+    }
+  }
+
+  Ok(())
+}
+
+fn set_floating_window_position(
+  window: NonTilingWindow,
+  centered: bool,
+  target_x_pos: Option<LengthValue>,
+  target_y_pos: Option<LengthValue>,
+  state: &mut WmState,
+) -> anyhow::Result<()> {
+  let window_rect = window.to_rect()?;
+
+  match centered {
+    true => {
+      let workspace =
+      window.workspace().context("no workspace find.")?;
+      window.set_floating_placement(
+        window_rect
+        .translate_to_center(&workspace.to_rect()?),
+      )         
+    },
+    false => {
+      let monitor = window.monitor().context("No monitor")?;
+      let monitor_rect = monitor.to_rect()?;
+    
+      let target_x_pos_px = target_x_pos
+      .map(|target_x_pos| target_x_pos.to_px(monitor_rect.x(), None));
+      let target_y_pos_px = target_y_pos
+      .map(|target_y_pos| target_y_pos.to_px(monitor_rect.y(), None));
+    
+      let new_x_pos = target_x_pos_px.unwrap_or(window_rect.x());
+      let new_y_pos = target_y_pos_px.unwrap_or(window_rect.y());
+
+      window.set_floating_placement(Rect::from_xy(
+        new_x_pos,
+        new_y_pos,
+        window.floating_placement().width(),
+        window.floating_placement().height(),
+      ));
+    }
+  }
+
+  state
+    .pending_sync
+    .containers_to_redraw
+    .push(window.clone().into());
+
+  Ok(())
+}


### PR DESCRIPTION
This pr allows you to set size,position and centered status of the window when setting it to float, so that the launch size,position and center can be specified in the window open rule