### PR TITLE
feat(config): Window Animations by config

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ general:
   # workspace when focusing the current workspace.
   toggle_workspace_on_refocus: false
 
+  # Whether to animate windows when switching between focused workspaces
+  window_animations: true
+
   cursor_jump:
     # Whether to automatically move the cursor on the specified trigger.
     enabled: true

--- a/packages/wm/src/common/commands/reload_config.rs
+++ b/packages/wm/src/common/commands/reload_config.rs
@@ -2,13 +2,7 @@ use anyhow::Context;
 use tracing::{info, warn};
 
 use crate::{
-  app_command::InvokeCommand,
-  containers::traits::{CommonGetters, TilingSizeGetters},
-  user_config::{ParsedConfig, UserConfig, WindowRuleEvent},
-  windows::{commands::run_window_rules, traits::WindowGetters},
-  wm_event::WmEvent,
-  wm_state::WmState,
-  workspaces::commands::sort_workspaces,
+  app_command::InvokeCommand, common::platform::Platform, containers::traits::{CommonGetters, TilingSizeGetters}, user_config::{ParsedConfig, UserConfig, WindowRuleEvent}, windows::{commands::run_window_rules, traits::WindowGetters}, wm_event::WmEvent, wm_state::WmState, workspaces::commands::sort_workspaces
 };
 
 pub fn reload_config(
@@ -139,8 +133,16 @@ fn update_window_effects(
   let focused_container =
     state.focused_container().context("No focused container.")?;
 
+
+  let general_config = &config.value.general;
+  let old_general_config = &old_config.general;
+
   let window_effects = &config.value.window_effects;
   let old_window_effects = &old_config.window_effects;
+
+  if general_config.window_animations != old_general_config.window_animations {
+    Platform::set_window_animations_enabled(general_config.window_animations)?;
+  }
 
   // Window border effects are left at system defaults if disabled in the
   // config. However, when transitioning from colored borders to having

--- a/packages/wm/src/main.rs
+++ b/packages/wm/src/main.rs
@@ -110,7 +110,7 @@ async fn start_wm(
   start_watcher_process()?;
 
   // Add application icon to system tray.
-  let mut tray = SystemTray::new(&config.path)?;
+  let mut tray = SystemTray::new(&mut config)?;
 
   let mut wm = WindowManager::new(&mut config)?;
 

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -410,6 +410,9 @@ pub struct GeneralConfig {
   /// Commands to run after the WM config has reloaded.
   #[serde(default)]
   pub config_reload_commands: Vec<InvokeCommand>,
+
+  #[serde(default = "default_bool::<true>")]
+  pub window_animations: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Added the ability to turn off window animations by default via the config, by default it is enabled like it was before.

Ps. Please let me know what formatter to use on this, I use VSCode default one and it appears to have changed something, sorry.