### PR TITLE
feat: add `--hide-window` flag to allow `shell-exec` to run commands in background

### DIFF
--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -212,7 +212,7 @@ pub enum InvokeCommand {
   ShellExec {
     #[clap(long, action)]
     hide_window: bool,
-    
+
     #[clap(required = true, trailing_var_arg = true)]
     command: Vec<String>,
   },

--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -210,9 +210,9 @@ pub enum InvokeCommand {
     visibility: TitleBarVisibility,
   },
   ShellExec {
-    #[clap(long, default_missing_value = "true", require_equals = true, num_args = 0..=1)]
-    hide_window: Option<bool>,
-
+    #[clap(long, action)]
+    hide_window: bool,
+    
     #[clap(required = true, trailing_var_arg = true)]
     command: Vec<String>,
   },
@@ -537,7 +537,7 @@ impl InvokeCommand {
         hide_window,
         command 
       } => {
-        shell_exec(&command.join(" "), hide_window.unwrap_or(false))
+        shell_exec(&command.join(" "), hide_window.clone())
       }
       InvokeCommand::Size(args) => {
         match subject_container.as_window_container() {

--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -210,6 +210,9 @@ pub enum InvokeCommand {
     visibility: TitleBarVisibility,
   },
   ShellExec {
+    #[clap(long, default_missing_value = "true", require_equals = true, num_args = 0..=1)]
+    hide_window: Option<bool>,
+
     #[clap(required = true, trailing_var_arg = true)]
     command: Vec<String>,
   },
@@ -530,8 +533,15 @@ impl InvokeCommand {
           _ => Ok(()),
         }
       }
-      InvokeCommand::ShellExec { command } => {
-        shell_exec(&command.join(" "))
+      InvokeCommand::ShellExec { 
+        hide_window,
+        command 
+      } => {
+        if let Some(true) = hide_window {
+          shell_exec(&command.join(" "),true)
+        } else {
+          shell_exec(&command.join(" "),false)
+        }
       }
       InvokeCommand::Size(args) => {
         match subject_container.as_window_container() {

--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -537,11 +537,7 @@ impl InvokeCommand {
         hide_window,
         command 
       } => {
-        if let Some(true) = hide_window {
-          shell_exec(&command.join(" "),true)
-        } else {
-          shell_exec(&command.join(" "),false)
-        }
+        shell_exec(&command.join(" "), hide_window.unwrap_or(false))
       }
       InvokeCommand::Size(args) => {
         match subject_container.as_window_container() {

--- a/packages/wm/src/common/commands/shell_exec.rs
+++ b/packages/wm/src/common/commands/shell_exec.rs
@@ -2,12 +2,12 @@ use tracing::{error, info};
 
 use crate::common::platform::Platform;
 
-pub fn shell_exec(command: &str) -> anyhow::Result<()> {
+pub fn shell_exec(command: &str,hide_window: bool) -> anyhow::Result<()> {
   let res =
     Platform::parse_command(command).and_then(|(program, args)| {
       info!("Parsed command program: '{}', args: '{}'.", program, args);
 
-      Platform::run_command(&program, &args)
+      Platform::run_command(&program, &args, hide_window)
     });
 
   match res {

--- a/packages/wm/src/common/commands/shell_exec.rs
+++ b/packages/wm/src/common/commands/shell_exec.rs
@@ -2,7 +2,7 @@ use tracing::{error, info};
 
 use crate::common::platform::Platform;
 
-pub fn shell_exec(command: &str,hide_window: bool) -> anyhow::Result<()> {
+pub fn shell_exec(command: &str, hide_window: bool) -> anyhow::Result<()> {
   let res =
     Platform::parse_command(command).and_then(|(program, args)| {
       info!("Parsed command program: '{}', args: '{}'.", program, args);

--- a/packages/wm/src/common/platform/platform.rs
+++ b/packages/wm/src/common/platform/platform.rs
@@ -24,7 +24,7 @@ use windows::{
         SystemParametersInfoW, TranslateMessage, WindowFromPoint,
         ANIMATIONINFO, CS_HREDRAW, CS_VREDRAW, CW_USEDEFAULT, GA_ROOT,
         MB_ICONERROR, MB_OK, MB_SYSTEMMODAL, MSG, PM_REMOVE,
-        SPI_GETANIMATION, SPI_SETANIMATION, SW_NORMAL,
+        SPI_GETANIMATION, SPI_SETANIMATION, SW_NORMAL, SW_HIDE,
         SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, WM_QUIT, WNDCLASSW, WNDPROC,
         WS_OVERLAPPEDWINDOW,
       },
@@ -411,7 +411,7 @@ impl Platform {
   }
 
   /// Runs the specified program with the given arguments.
-  pub fn run_command(program: &str, args: &str) -> anyhow::Result<()> {
+  pub fn run_command(program: &str, args: &str, hide_window: bool) -> anyhow::Result<()> {
     let home_dir = home::home_dir()
       .context("Unable to get home directory.")?
       .to_str()
@@ -435,7 +435,7 @@ impl Platform {
       lpFile: PCWSTR(program_wide.as_ptr()),
       lpParameters: PCWSTR(args_wide.as_ptr()),
       lpDirectory: PCWSTR(home_dir_wide.as_ptr()),
-      nShow: SW_NORMAL.0 as _,
+      nShow: if hide_window { SW_HIDE } else { SW_NORMAL }.0 as _,
       fMask: SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NOASYNC,
       ..Default::default()
     };


### PR DESCRIPTION

This will allow some terminal commands to be executed without pop-ups, such as powershell,nushell



before：


https://github.com/user-attachments/assets/043783e5-7dfb-4117-973e-5052cfb623d0


apply this pr:
```powershell
  - commands: ["shell-exec --hide-window nu ~/script/clash.nu"]
    bindings: ["Ctrl+Enter"]
```

https://github.com/user-attachments/assets/3c2000fd-e02e-41e0-baad-96985add4e78


