### PR TITLE
fix: set focus to valid desktop window in an empty workspace

### DIFF
--- a/packages/wm/src/common/platform/platform.rs
+++ b/packages/wm/src/common/platform/platform.rs
@@ -19,9 +19,9 @@ use windows::{
       },
       WindowsAndMessaging::{
         CreateWindowExW, DispatchMessageW, GetAncestor, GetCursorPos,
-        FindWindowA, GetForegroundWindow, GetMessageW, MessageBoxW,
+        GetDesktopWindow, GetForegroundWindow, GetMessageW, MessageBoxW,
         PeekMessageW, PostThreadMessageW, RegisterClassW, SetCursorPos,
-        SystemParametersInfoW, TranslateMessage, WindowFromPoint,
+        SystemParametersInfoW, TranslateMessage, WindowFromPoint, GetShellWindow,
         ANIMATIONINFO, CS_HREDRAW, CS_VREDRAW, CW_USEDEFAULT, GA_ROOT,
         MB_ICONERROR, MB_OK, MB_SYSTEMMODAL, MSG, PM_REMOVE,
         SPI_GETANIMATION, SPI_SETANIMATION, SW_NORMAL,
@@ -49,11 +49,14 @@ impl Platform {
     NativeWindow::new(handle.0)
   }
 
-  /// Gets the `NativeWindow` instance of the desktop window.
+  // Get Explorer wallpaper window (i.e. "Progman"). Default to the
+  // desktop window on which the wallpaper window sits above for edge
+  // case where Explorer isn't running.
   pub fn desktop_window() -> NativeWindow {
-    let  handle = unsafe {
-      FindWindowA(PCSTR("Progman\0".as_ptr() as *const u8), PCSTR::null())
-    };
+    let mut handle = unsafe { GetShellWindow() };
+    if handle == HWND(0) {
+      handle = unsafe { GetDesktopWindow() };
+    }
     NativeWindow::new(handle.0)
   }
 

--- a/packages/wm/src/common/platform/platform.rs
+++ b/packages/wm/src/common/platform/platform.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{bail, Context};
 use windows::{
-  core::{w, PCWSTR},
+  core::{w, PCWSTR, PCSTR},
   Win32::{
     Foundation::{HANDLE, HWND, LPARAM, POINT, WPARAM},
     System::{
@@ -19,7 +19,7 @@ use windows::{
       },
       WindowsAndMessaging::{
         CreateWindowExW, DispatchMessageW, GetAncestor, GetCursorPos,
-        GetDesktopWindow, GetForegroundWindow, GetMessageW, MessageBoxW,
+        FindWindowA, GetForegroundWindow, GetMessageW, MessageBoxW,
         PeekMessageW, PostThreadMessageW, RegisterClassW, SetCursorPos,
         SystemParametersInfoW, TranslateMessage, WindowFromPoint,
         ANIMATIONINFO, CS_HREDRAW, CS_VREDRAW, CW_USEDEFAULT, GA_ROOT,
@@ -51,7 +51,9 @@ impl Platform {
 
   /// Gets the `NativeWindow` instance of the desktop window.
   pub fn desktop_window() -> NativeWindow {
-    let handle = unsafe { GetDesktopWindow() };
+    let  handle = unsafe {
+      FindWindowA(PCSTR("Progman\0".as_ptr() as *const u8), PCSTR::null())
+    };
     NativeWindow::new(handle.0)
   }
 

--- a/packages/wm/src/common/platform/platform.rs
+++ b/packages/wm/src/common/platform/platform.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{bail, Context};
 use windows::{
-  core::{w, PCWSTR, PCSTR},
+  core::{w, PCWSTR},
   Win32::{
     Foundation::{HANDLE, HWND, LPARAM, POINT, WPARAM},
     System::{


### PR DESCRIPTION
When switching to an empty workspace, we should logically focus on the desktop window, but in practice it fails, leaving us in a state where no window is focused, resulting in some window-event-based applications working abnormally, such as ahk:

desktop windows focus fail:

the windows message catch tool message: "can't get any focus window"

https://github.com/user-attachments/assets/9595f96c-398f-4c26-bfcd-e9fd292e87da


apply this pr:

https://github.com/user-attachments/assets/dd426f36-6e73-420d-9803-3f9304c78dd6

