### PR TITLE
fix: regression in layouting with fullscreen state and various taskbar alignments

### DIFF
--- a/packages/wm/src/common/events/handle_window_focused.rs
+++ b/packages/wm/src/common/events/handle_window_focused.rs
@@ -2,12 +2,15 @@ use anyhow::Context;
 use tracing::info;
 
 use crate::{
-  common::{platform::NativeWindow, DisplayState},
+  common::{
+    platform::NativeWindow,
+    DisplayState
+  },
   containers::{commands::set_focused_descendant, traits::CommonGetters},
   user_config::{UserConfig, WindowRuleEvent},
-  windows::{commands::run_window_rules, traits::WindowGetters},
+  windows::{commands::{run_window_rules, update_window_state}, traits::WindowGetters, WindowState},
   wm_state::WmState,
-  workspaces::{commands::focus_workspace, WorkspaceTarget},
+  workspaces::{commands::focus_workspace, WorkspaceTarget}
 };
 
 pub fn handle_window_focused(
@@ -27,9 +30,16 @@ pub fn handle_window_focused(
       return Ok(());
     }
 
+    // Handle minimizing fullscreen window if another non-floating window container is being focused
+    if let Some(fullscreen_window) = window.workspace().unwrap().get_fullscreen_window() {
+      if !matches!(window.state(), WindowState::Floating(_)) {
+        update_window_state(fullscreen_window, WindowState::Minimized, state, config)?;
+      }
+    }
+    
     // TODO: Log window details.
     info!("Window focused");
-
+    
     // Handle overriding focus on close/minimize. After a window is closed
     // or minimized, the OS or the closed application might automatically
     // switch focus to a different window. To force focus to go to the WM's

--- a/packages/wm/src/common/events/handle_window_hidden.rs
+++ b/packages/wm/src/common/events/handle_window_hidden.rs
@@ -22,7 +22,7 @@ pub fn handle_window_hidden(
       return Ok(());
     }
 
-    // Unmanage the window if it's not in a display state transition. Also,
+    // Unmanage thed window if it's not in a display state transition. Also,
     // since window events are not 100% guaranteed to be in correct order,
     // we need to ignore events where the window is not actually hidden.
     if window.display_state() == DisplayState::Shown

--- a/packages/wm/src/common/events/handle_window_location_changed.rs
+++ b/packages/wm/src/common/events/handle_window_location_changed.rs
@@ -5,7 +5,7 @@ use crate::{
   common::{platform::NativeWindow, Rect},
   containers::{
     commands::{flatten_split_container, move_container_within_tree},
-    traits::{CommonGetters, PositionGetters},
+    traits::CommonGetters,
     WindowContainer,
   },
   try_warn,
@@ -50,14 +50,9 @@ pub fn handle_window_location_changed(
       )?;
     }
 
-    let monitor_rect = if config.has_outer_gaps() {
-      nearest_monitor.native().working_rect()?.clone()
-    } else {
-      nearest_monitor.to_rect()?
-    };
-
-    let is_fullscreen = window.native().is_fullscreen(&monitor_rect)?;
-
+    let is_fullscreen = window.native().is_fullscreen(
+      nearest_monitor.native().working_rect()?
+    )?;
     match window.state() {
       WindowState::Fullscreen(fullscreen_state) => {
         // A fullscreen window that gets minimized can hit this arm, so
@@ -92,9 +87,8 @@ pub fn handle_window_location_changed(
       }
       _ => {
         // Update the window to be fullscreen if there's been a change in
-        // maximized state or if the window is now fullscreen.
-        if (is_maximized && old_is_maximized != is_maximized)
-          || is_fullscreen
+        // maximized state
+        if is_maximized && old_is_maximized != is_maximized
         {
           info!("Window fullscreened");
 

--- a/packages/wm/src/common/events/handle_window_location_changed.rs
+++ b/packages/wm/src/common/events/handle_window_location_changed.rs
@@ -26,6 +26,7 @@ pub fn handle_window_location_changed(
 
   // Update the window's state to be fullscreen or toggled from fullscreen.
   if let Some(window) = found_window {
+
     let old_frame_position = window.native().frame_position()?;
     let frame_position =
       try_warn!(window.native().refresh_frame_position());
@@ -49,16 +50,13 @@ pub fn handle_window_location_changed(
         config,
       )?;
     }
-
-    let is_fullscreen = window.native().is_fullscreen(
-      nearest_monitor.native().working_rect()?
-    )?;
     match window.state() {
       WindowState::Fullscreen(fullscreen_state) => {
-        // A fullscreen window that gets minimized can hit this arm, so
+        // A full working area window that gets minimized can hit this arm, so
         // ignore such events and let it be handled by the handler for
         // `PlatformEvent::WindowMinimized` instead.
-        if !(is_fullscreen || is_maximized || !is_minimized) {
+        let is_full_work_area = window.native().is_full_work_area(&nearest_monitor.native())?;
+        if !(is_full_work_area || is_maximized) && !is_minimized {
           info!("Window restored");
 
           let target_state = window
@@ -88,7 +86,9 @@ pub fn handle_window_location_changed(
       _ => {
         // Update the window to be fullscreen if there's been a change in
         // maximized state
-        if is_maximized && old_is_maximized != is_maximized
+        let is_fullscreen = window.native()
+          .is_fullscreen(&nearest_monitor.native())?;
+        if (is_maximized && old_is_maximized != is_maximized) || is_fullscreen
         {
           info!("Window fullscreened");
 

--- a/packages/wm/src/common/rect.rs
+++ b/packages/wm/src/common/rect.rs
@@ -125,32 +125,6 @@ impl Rect {
     }
   }
 
-  pub fn apply_delta(
-    &self,
-    delta: &RectDelta,
-    scale_factor: Option<f32>,
-  ) -> Self {
-    Self::from_ltrb(
-      self.left - delta.left.to_px(self.width(), scale_factor),
-      self.top - delta.top.to_px(self.height(), scale_factor),
-      self.right + delta.right.to_px(self.width(), scale_factor),
-      self.bottom + delta.bottom.to_px(self.height(), scale_factor),
-    )
-  }
-
-  pub fn apply_inverse_delta(
-    &self,
-    delta: &RectDelta,
-    scale_factor: Option<f32>,
-  ) -> Self {
-    Self::from_ltrb(
-      self.left + delta.left.to_px(self.width(), scale_factor),
-      self.top + delta.top.to_px(self.height(), scale_factor),
-      self.right - delta.right.to_px(self.width(), scale_factor),
-      self.bottom - delta.bottom.to_px(self.height(), scale_factor),
-    )
-  }
-
   // Gets whether the x-coordinate overlaps with the x-coordinate of the
   // other rect.
   pub fn has_overlap_x(&self, other: &Rect) -> bool {

--- a/packages/wm/src/containers/traits/common_getters.rs
+++ b/packages/wm/src/containers/traits/common_getters.rs
@@ -286,10 +286,6 @@ pub trait CommonGetters {
       .chain(end_ancestor.clone())
       .all(|ancestor| ancestor.focus_index() == 0)
   }
-
-  fn focused_container(&self) -> Option<Container> {
-    self.child_by_id(self.borrow_child_focus_order().iter().next().unwrap())
-  }
 }
 
 /// An iterator over ancestors of a given container.

--- a/packages/wm/src/containers/traits/common_getters.rs
+++ b/packages/wm/src/containers/traits/common_getters.rs
@@ -286,6 +286,10 @@ pub trait CommonGetters {
       .chain(end_ancestor.clone())
       .all(|ancestor| ancestor.focus_index() == 0)
   }
+
+  fn focused_container(&self) -> Option<Container> {
+    self.child_by_id(self.borrow_child_focus_order().iter().next().unwrap())
+  }
 }
 
 /// An iterator over ancestors of a given container.

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -330,16 +330,6 @@ impl UserConfig {
       self.workspace_config_index(&workspace.config().name)
     });
   }
-
-  pub fn has_outer_gaps(&self) -> bool {
-    let outer_gap = &self.value.gaps.outer_gap;
-
-    // Allow for 1px/1% of leeway.
-    outer_gap.bottom.amount > 1.0
-      || outer_gap.left.amount > 1.0
-      || outer_gap.right.amount > 1.0
-      || outer_gap.top.amount > 1.0
-  }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/packages/wm/src/windows/commands/manage_window.rs
+++ b/packages/wm/src/windows/commands/manage_window.rs
@@ -12,7 +12,7 @@ use crate::{
   try_warn,
   user_config::{UserConfig, WindowRuleEvent},
   windows::{
-    commands::run_window_rules, traits::WindowGetters, NonTilingWindow,
+    commands::{run_window_rules, update_window_state}, traits::WindowGetters, NonTilingWindow,
     TilingWindow, WindowState,
   },
   wm_event::WmEvent,
@@ -45,6 +45,13 @@ pub fn manage_window(
   if let Some(window) = updated_window {
     // TODO: Log window details.
     info!("New window managed");
+
+    // Handle minimizing fullscreen window if another non-floating window container is being managed
+    if let Some(fullscreen_window) = window.workspace().unwrap().get_fullscreen_window() {
+      if !matches!(window.state(), WindowState::Floating(_)) {
+        update_window_state(fullscreen_window, WindowState::Minimized, state, config)?;
+      }
+    }
 
     state.emit_event(WmEvent::WindowManaged {
       managed_window: window.to_dto()?,
@@ -182,13 +189,7 @@ fn window_state_to_create(
     return Ok(WindowState::Minimized);
   }
 
-  let monitor_rect = if config.has_outer_gaps() {
-    nearest_monitor.native().working_rect()?.clone()
-  } else {
-    nearest_monitor.to_rect()?
-  };
-
-  if native_window.is_fullscreen(&monitor_rect)? {
+  if native_window.is_fullscreen(&nearest_monitor.native())? {
     return Ok(WindowState::Fullscreen(
       config
         .value

--- a/packages/wm/src/windows/commands/update_window_state.rs
+++ b/packages/wm/src/windows/commands/update_window_state.rs
@@ -29,6 +29,13 @@ pub fn update_window_state(
 
   info!("Updating window state: {:?}.", target_state);
 
+  // Handle minimizing fullscreen window if floating window container is changing its state to non-floating state
+  if let Some(fullscreen_window) = window.workspace().unwrap().get_fullscreen_window() {
+    if window != fullscreen_window && !matches!(target_state, WindowState::Floating(_)) && matches!(window.state(), WindowState::Floating(_)) {
+      update_window_state(fullscreen_window, WindowState::Minimized, state, config)?;
+    }
+  }
+
   match target_state {
     WindowState::Tiling => set_tiling(window, state, config),
     _ => set_non_tiling(window, target_state, state),

--- a/packages/wm/src/windows/non_tiling_window.rs
+++ b/packages/wm/src/windows/non_tiling_window.rs
@@ -131,7 +131,11 @@ impl PositionGetters for NonTilingWindow {
   fn to_rect(&self) -> anyhow::Result<Rect> {
     match self.state() {
       WindowState::Fullscreen(_) => {
-        Ok(self.monitor().context("No monitor.")?.native().working_rect()?.clone())
+        let native_monitor = self.monitor().context("No monitor.")?.native();
+        Ok(match self.native().is_fullscreen(&native_monitor)? {
+          true => native_monitor.rect()?.clone(),
+          false => native_monitor.working_rect()?.clone()
+        })
       }
       _ => Ok(self.floating_placement()),
     }

--- a/packages/wm/src/windows/non_tiling_window.rs
+++ b/packages/wm/src/windows/non_tiling_window.rs
@@ -131,7 +131,7 @@ impl PositionGetters for NonTilingWindow {
   fn to_rect(&self) -> anyhow::Result<Rect> {
     match self.state() {
       WindowState::Fullscreen(_) => {
-        self.monitor().context("No monitor.")?.to_rect()
+        Ok(self.monitor().context("No monitor.")?.native().working_rect()?.clone())
       }
       _ => Ok(self.floating_placement()),
     }

--- a/packages/wm/src/workspaces/workspace.rs
+++ b/packages/wm/src/workspaces/workspace.rs
@@ -13,11 +13,11 @@ use crate::{
   containers::{
     traits::{CommonGetters, PositionGetters, TilingDirectionGetters},
     Container, ContainerDto, DirectionContainer, TilingContainer,
-    WindowContainer,
+    WindowContainer
   },
   impl_common_getters, impl_container_debug,
   impl_tiling_direction_getters,
-  user_config::{GapsConfig, WorkspaceConfig},
+  user_config::{GapsConfig, WorkspaceConfig}, windows::{traits::WindowGetters, WindowState}
 };
 
 #[derive(Clone)]
@@ -72,6 +72,19 @@ impl Workspace {
     };
 
     Self(Rc::new(RefCell::new(workspace)))
+  }
+
+  pub fn get_fullscreen_window(&self) -> Option<WindowContainer> {
+    match self.borrow_children().iter().find(|container| {
+      if let Ok(window_container) = container.as_window_container() {
+        matches!(window_container.state(), WindowState::Fullscreen(_))
+      } else {
+        false 
+      } 
+    }) {
+      Some(container) => Some(container.as_window_container().ok()?),
+      _ => None
+    }
   }
 
   /// Underlying config for the workspace.


### PR DESCRIPTION
# This PR implements fixes for #790 and #640 issues

I've tested **StartAllBack** and **Windhawk's top taskbar mod** by @m417z , but I am pretty confident **ExplorerPatcher** would also work due to the nature of **StartAllBack**'s use of classic taskbar.

**Note:** I've learned Rust basics just because how annoying this bug was for me, so if you see some spots which look kind of bad in the code, please review it 🤣

**Implementation note**: This PR completely removes `Rect`'s `apply_delta()` and `apply_inverse_delta()` functions as they were suited only for `Window` calculations, completely ignoring `Workspace` delta requirements. All of the calculations required to fix this in this PR were made in-place by constructing a `Rect` via`Rect::from_ltrb()` function instead.

# Before (this issue persists since at least GlazeWM 3.4.0):

https://github.com/user-attachments/assets/49232096-19f2-467a-a81d-8d88800ff994


https://github.com/user-attachments/assets/12377265-a8ef-4295-8463-ee648e9ff092

# After:

https://github.com/user-attachments/assets/7c464d72-37ea-48bb-b2e3-ce8c375e8b33


https://github.com/user-attachments/assets/b71bb32e-8712-44e0-bc70-8ef2a52aad97
