### PR TITLE
fix: change cargo lib and bin path to enable build on WSL

### DIFF
--- a/packages/wm/Cargo.toml
+++ b/packages/wm/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2021"
 default-run = "glazewm"
 
 [lib]
-path = "src\\lib.rs"
+path = "src/lib.rs"
 
 [[bin]]
 name = "glazewm"
-path = "src\\main.rs"
+path = "src/main.rs"
 
 [features]
 no_console = []


### PR DESCRIPTION
The project cannot be cross-compiled on Linux, because the file paths are in a format which is supported by Windows only:

```toml
[lib]
path = "src\\lib.rs"

[[bin]]
name = "glazewm"
path = "src\\main.rs"
```

Changing `\\` to `/` fixes the issue and works both, on Linux and on Windows.

Motivation: My whole developer workflow is on WSL. My typical workflow is to build on WSL and then test on Windows.

## How to build `glazewm` on Ubuntu:

(assuming this patch is applied and nightly is setup already)

1. Install dependencies: `sudo apt-get update; sudo apt-get install libgtk-3-dev librust-atk-dev`
2. Add windows (gnu) target: `rustup target add x86_64-pc-windows-gnu`
3. Finally, build the project: ` cargo build --target x86_64-pc-windows-gnu`