### PR TITLE
refactor: clippy fixes and working doctests

### DIFF
--- a/packages/watcher/src/main.rs
+++ b/packages/watcher/src/main.rs
@@ -12,6 +12,8 @@ use wm::{
 };
 
 #[tokio::main]
+// Clippy picks up on a return that is likely added by `#[tokio::main]`.
+#[allow(clippy::needless_return)]
 async fn main() -> anyhow::Result<()> {
   tracing_subscriber::fmt().init();
 
@@ -35,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
 
       let managed_windows = managed_handles
         .into_iter()
-        .map(|handle| NativeWindow::new(handle))
+        .map(NativeWindow::new)
         .collect::<Vec<_>>();
 
       run_cleanup(managed_windows);
@@ -56,7 +58,7 @@ async fn query_initial_windows(
     .context("Failed to send window query command.")?;
 
   client
-    .client_response(&query_message)
+    .client_response(query_message)
     .await
     .and_then(|response| match response.data {
       Some(ClientResponseData::Windows(data)) => Some(data),
@@ -83,12 +85,12 @@ async fn watch_managed_handles(
     "sub -e window_managed window_unmanaged application_exiting";
 
   client
-    .send(&subscription_message)
+    .send(subscription_message)
     .await
     .context("Failed to send subscribe command to IPC server.")?;
 
   let subscription_id = client
-    .client_response(&subscription_message)
+    .client_response(subscription_message)
     .await
     .and_then(|response| match response.data {
       Some(ClientResponseData::EventSubscribe(data)) => {

--- a/packages/watcher/src/main.rs
+++ b/packages/watcher/src/main.rs
@@ -12,8 +12,6 @@ use wm::{
 };
 
 #[tokio::main]
-// Clippy picks up on a return that is likely added by `#[tokio::main]`.
-#[allow(clippy::needless_return)]
 async fn main() -> anyhow::Result<()> {
   tracing_subscriber::fmt().init();
 

--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -38,7 +38,7 @@ use crate::{
   },
 };
 
-const VERSION: &'static str = env!("VERSION_NUMBER");
+const VERSION: &str = env!("VERSION_NUMBER");
 
 #[derive(Clone, Debug, Parser)]
 #[clap(author, version = VERSION, about, long_about = None)]
@@ -522,11 +522,7 @@ impl InvokeCommand {
         match subject_container.as_window_container() {
           Ok(window) => {
             _ = window.native().set_title_bar_visibility(
-              if *visibility == TitleBarVisibility::Shown {
-                true
-              } else {
-                false
-              },
+              *visibility == TitleBarVisibility::Shown,
             );
             Ok(())
           }
@@ -536,7 +532,7 @@ impl InvokeCommand {
       InvokeCommand::ShellExec {
         hide_window,
         command,
-      } => shell_exec(&command.join(" "), hide_window.clone()),
+      } => shell_exec(&command.join(" "), *hide_window),
       InvokeCommand::Size(args) => {
         match subject_container.as_window_container() {
           Ok(window) => set_window_size(

--- a/packages/wm/src/common/commands/cycle_focus.rs
+++ b/packages/wm/src/common/commands/cycle_focus.rs
@@ -46,12 +46,14 @@ pub fn cycle_focus(
       let window_of_type = workspace
         .descendant_focus_order()
         .filter_map(|descendant| descendant.as_window_container().ok())
-        .find(|descendant| match (descendant.state(), &next) {
-          (WindowState::Floating(_), WindowState::Floating(_)) => true,
-          (WindowState::Fullscreen(_), WindowState::Fullscreen(_)) => true,
-          (WindowState::Minimized, WindowState::Minimized) => true,
-          (WindowState::Tiling, WindowState::Tiling) => true,
-          _ => false,
+        .find(|descendant| {
+          matches!(
+            (descendant.state(), &next),
+            (WindowState::Floating(_), WindowState::Floating(_))
+              | (WindowState::Fullscreen(_), WindowState::Fullscreen(_))
+              | (WindowState::Minimized, WindowState::Minimized)
+              | (WindowState::Tiling, WindowState::Tiling)
+          )
         });
 
       if let Some(window) = window_of_type {

--- a/packages/wm/src/common/commands/platform_sync.rs
+++ b/packages/wm/src/common/commands/platform_sync.rs
@@ -22,7 +22,7 @@ pub fn platform_sync(
   state: &mut WmState,
   config: &UserConfig,
 ) -> anyhow::Result<()> {
-  if state.pending_sync.containers_to_redraw.len() > 0 {
+  if !state.pending_sync.containers_to_redraw.is_empty() {
     redraw_containers(state)?;
     state.pending_sync.containers_to_redraw.clear();
   }
@@ -129,10 +129,10 @@ fn redraw_containers(state: &mut WmState) -> anyhow::Result<()> {
       .to_rect()?
       .apply_delta(&window.total_border_delta()?, None);
 
-    let is_visible = match window.display_state() {
-      DisplayState::Showing | DisplayState::Shown => true,
-      _ => false,
-    };
+    let is_visible = matches!(
+      window.display_state(),
+      DisplayState::Showing | DisplayState::Shown
+    );
 
     if let Err(err) = window.native().set_position(
       &window.state(),

--- a/packages/wm/src/common/commands/reload_config.rs
+++ b/packages/wm/src/common/commands/reload_config.rs
@@ -119,7 +119,6 @@ fn update_container_gaps(state: &mut WmState, config: &UserConfig) {
   let tiling_containers = state
     .root_container
     .self_and_descendants()
-    .into_iter()
     .filter_map(|container| container.as_tiling_container().ok());
 
   for container in tiling_containers {

--- a/packages/wm/src/common/direction.rs
+++ b/packages/wm/src/common/direction.rs
@@ -17,7 +17,9 @@ impl Direction {
   ///
   /// Example:
   /// ```
-  /// Direction::Left.inverse() // Direction::Right
+  /// # use wm::common::Direction;
+  /// let dir = Direction::Left.inverse();
+  /// assert_eq!(dir, Direction::Right);
   /// ```
   pub fn inverse(&self) -> Direction {
     match self {
@@ -36,7 +38,10 @@ impl FromStr for Direction {
   ///
   /// Example:
   /// ```
-  /// Direction::from_str("left") // Direction::Left
+  /// # use wm::common::Direction;
+  /// # use std::str::FromStr;
+  /// let dir = Direction::from_str("left");
+  /// assert_eq!(dir.unwrap(), Direction::Left);
   /// ```
   fn from_str(unparsed: &str) -> anyhow::Result<Self> {
     match unparsed {

--- a/packages/wm/src/common/events/handle_display_settings_changed.rs
+++ b/packages/wm/src/common/events/handle_display_settings_changed.rs
@@ -85,7 +85,7 @@ pub fn handle_display_settings_changed(
   }
 
   for native_monitor in new_native_monitors {
-    match pending_monitors.get(0) {
+    match pending_monitors.first() {
       Some(_) => {
         let monitor = pending_monitors.remove(0);
         update_monitor(monitor, native_monitor, state)

--- a/packages/wm/src/common/events/handle_window_location_changed.rs
+++ b/packages/wm/src/common/events/handle_window_location_changed.rs
@@ -63,7 +63,7 @@ pub fn handle_window_location_changed(
         // A fullscreen window that gets minimized can hit this arm, so
         // ignore such events and let it be handled by the handler for
         // `PlatformEvent::WindowMinimized` instead.
-        if !(is_fullscreen || is_maximized) && !is_minimized {
+        if !(is_fullscreen || is_maximized || !is_minimized) {
           info!("Window restored");
 
           let target_state = window

--- a/packages/wm/src/common/events/handle_window_minimized.rs
+++ b/packages/wm/src/common/events/handle_window_minimized.rs
@@ -34,8 +34,7 @@ pub fn handle_window_minimized(
       )?;
 
       // Focus should be reassigned after a window has been minimized.
-      if let Some(focus_target) =
-        state.focus_target_after_removal(&window.into())
+      if let Some(focus_target) = state.focus_target_after_removal(&window)
       {
         set_focused_descendant(focus_target, None);
         state.pending_sync.focus_change = true;

--- a/packages/wm/src/common/length_value.rs
+++ b/packages/wm/src/common/length_value.rs
@@ -50,7 +50,14 @@ impl FromStr for LengthValue {
   ///
   /// Example:
   /// ```
-  /// LengthValue::from_str("100px") // { amount: 100.0, unit: LengthUnit::Pixel }
+  /// # use wm::common::{LengthValue, LengthUnit};
+  /// # use std::str::FromStr;
+  /// let check = LengthValue {
+  ///   amount: 100.0,
+  ///   unit: LengthUnit::Pixel,
+  /// };
+  /// let parsed = LengthValue::from_str("100px");
+  /// assert_eq!(parsed.unwrap(), check);
   /// ```
   fn from_str(unparsed: &str) -> anyhow::Result<Self> {
     let units_regex = Regex::new(r"([+-]?\d+)(%|px)?")?;

--- a/packages/wm/src/common/memo.rs
+++ b/packages/wm/src/common/memo.rs
@@ -10,15 +10,24 @@ where
   value: Arc<Mutex<Option<T>>>,
 }
 
+impl<T> Default for Memo<T>
+where
+  T: Clone,
+{
+  fn default() -> Self {
+    Memo {
+      value: Arc::new(Mutex::new(None)),
+    }
+  }
+}
+
 impl<T> Memo<T>
 where
   T: Clone,
 {
   /// Creates a new `Memo` instance with `None` as the initial value.
   pub fn new() -> Self {
-    Memo {
-      value: Arc::new(Mutex::new(None)),
-    }
+    Self::default()
   }
 
   /// Retrieves the cached value if it exists, otherwise initializes it
@@ -38,7 +47,7 @@ where
       .as_ref()
       .map(|value| Ok(value.clone()))
       .unwrap_or_else(|| {
-        let value = retriever_fn(&arg)?;
+        let value = retriever_fn(arg)?;
         *value_ref = Some(value.clone());
         Ok(value)
       })
@@ -53,7 +62,7 @@ where
   {
     let mut value_ref = self.value.lock().unwrap();
 
-    let value = retriever_fn(&arg)?;
+    let value = retriever_fn(arg)?;
     *value_ref = Some(value.clone());
     Ok(value)
   }

--- a/packages/wm/src/common/platform/event_listener.rs
+++ b/packages/wm/src/common/platform/event_listener.rs
@@ -62,7 +62,7 @@ impl EventListener {
   pub fn update(
     &mut self,
     config: &UserConfig,
-    binding_modes: &Vec<BindingModeConfig>,
+    binding_modes: &[BindingModeConfig],
   ) {
     // Modify keybindings based on active binding modes.
     let keybindings = match binding_modes.first() {

--- a/packages/wm/src/common/platform/keyboard_hook.rs
+++ b/packages/wm/src/common/platform/keyboard_hook.rs
@@ -121,11 +121,11 @@ impl KeyboardHook {
           .collect::<Vec<_>>();
 
         // Safety: A split string always has at least one element.
-        let trigger_key = vk_codes.last().unwrap().clone();
+        let trigger_key = *vk_codes.last().unwrap();
 
         keybinding_map
           .entry(trigger_key)
-          .or_insert_with(|| Vec::new())
+          .or_insert_with(Vec::new)
           .push(ActiveKeybinding {
             vk_codes,
             config: keybinding.clone(),

--- a/packages/wm/src/common/platform/native_monitor.rs
+++ b/packages/wm/src/common/platform/native_monitor.rs
@@ -88,9 +88,10 @@ impl NativeMonitor {
       // Get the display devices associated with the monitor.
       let mut display_devices = (0..)
         .map_while(|index| {
-          let mut display_device = DISPLAY_DEVICEW::default();
-          display_device.cb =
-            std::mem::size_of::<DISPLAY_DEVICEW>() as u32;
+          let mut display_device = DISPLAY_DEVICEW {
+            cb: std::mem::size_of::<DISPLAY_DEVICEW>() as u32,
+            ..Default::default()
+          };
 
           // Due to the `EDD_GET_DEVICE_INTERFACE_NAME` flag, the device
           // struct will contain the DOS device path under the `DeviceId`
@@ -104,7 +105,7 @@ impl NativeMonitor {
             )
           }
           .as_bool()
-          .then(|| display_device)
+          .then_some(display_device)
         })
         // Filter out any devices that are not active.
         .filter(|device| device.StateFlags & DISPLAY_DEVICE_ACTIVE != 0);
@@ -173,7 +174,7 @@ pub fn available_monitors() -> anyhow::Result<Vec<NativeMonitor>> {
   Ok(
     available_monitor_handles()?
       .into_iter()
-      .map(|handle| NativeMonitor::new(handle))
+      .map(NativeMonitor::new)
       .collect(),
   )
 }

--- a/packages/wm/src/common/platform/platform.rs
+++ b/packages/wm/src/common/platform/platform.rs
@@ -376,7 +376,7 @@ impl Platform {
     };
 
     let command_parts: Vec<&str> =
-      expanded_command.trim().split_whitespace().collect();
+      expanded_command.split_whitespace().collect();
 
     // If the command starts with double quotes, then the program name/path
     // is wrapped in double quotes (e.g. `"C:\path\to\app.exe" --flag`).
@@ -435,8 +435,8 @@ impl Platform {
     // causes issues where the pointer is dropped while `ShellExecuteExW`
     // is using it. This is likely a `windows-rs` bug, and we can avoid
     // it by keeping separate variables for the wide strings.
-    let program_wide = to_wide(&program);
-    let args_wide = to_wide(&args);
+    let program_wide = to_wide(program);
+    let args_wide = to_wide(args);
     let home_dir_wide = to_wide(&home_dir);
 
     // Using the built-in `Command::new` function in Rust launches the

--- a/packages/wm/src/common/platform/platform.rs
+++ b/packages/wm/src/common/platform/platform.rs
@@ -338,10 +338,7 @@ impl Platform {
   /// # Examples
   ///
   /// ```no_run
-  /// # // Since this checks if the path exists, not sure how to test this.
-  /// # // Don't think you can `use` a struct method.
   /// # use wm::common::platform::Platform;
-  /// fn main() -> anyhow::Result<()> {
   ///   let (prog, args) = Platform::parse_command("code .")?;
   ///   assert_eq!(prog, "code");
   ///   assert_eq!(args, ".");
@@ -351,9 +348,7 @@ impl Platform {
   ///   )?;
   ///   assert_eq!(prog, r#"C:\Program Files\Git\git-bash"#);
   ///   assert_eq!(args, r#"--cd=C:\Users\larsb\.glaze-wm"#);
-  ///
-  ///   Ok(())
-  /// }
+  /// # Ok::<(), anyhow::Error>(())
   /// ```
   pub fn parse_command(command: &str) -> anyhow::Result<(String, String)> {
     // Expand environment variables in the command string.

--- a/packages/wm/src/common/platform/platform.rs
+++ b/packages/wm/src/common/platform/platform.rs
@@ -337,16 +337,23 @@ impl Platform {
   ///
   /// # Examples
   ///
-  /// ```
-  /// let (prog, args) = parse_command("code .")?;
-  /// assert_eq!(prog, "code");
-  /// assert_eq!(args, ".");
+  /// ```no_run
+  /// # // Since this checks if the path exists, not sure how to test this.
+  /// # // Don't think you can `use` a struct method.
+  /// # use wm::common::platform::Platform;
+  /// fn main() -> anyhow::Result<()> {
+  ///   let (prog, args) = Platform::parse_command("code .")?;
+  ///   assert_eq!(prog, "code");
+  ///   assert_eq!(args, ".");
   ///
-  /// let (prog, args) = parse_command(
-  ///   r#"C:\Program Files\Git\git-bash --cd=C:\Users\larsb\.glaze-wm"#,
-  /// )?;
-  /// assert_eq!(prog, r#"C:\Program Files\Git\git-bash"#);
-  /// assert_eq!(args, r#"--cd=C:\Users\larsb\.glaze-wm"#);
+  ///   let (prog, args) = Platform::parse_command(
+  ///     r#"C:\Program Files\Git\git-bash --cd=C:\Users\larsb\.glaze-wm"#,
+  ///   )?;
+  ///   assert_eq!(prog, r#"C:\Program Files\Git\git-bash"#);
+  ///   assert_eq!(args, r#"--cd=C:\Users\larsb\.glaze-wm"#);
+  ///
+  ///   Ok(())
+  /// }
   /// ```
   pub fn parse_command(command: &str) -> anyhow::Result<(String, String)> {
     // Expand environment variables in the command string.

--- a/packages/wm/src/common/tiling_direction.rs
+++ b/packages/wm/src/common/tiling_direction.rs
@@ -17,7 +17,9 @@ impl TilingDirection {
   ///
   /// Example:
   /// ```
-  /// TilingDirection::Horizontal.inverse() // TilingDirection::Vertical
+  /// # use wm::common::TilingDirection;
+  /// let dir = TilingDirection::Horizontal.inverse();
+  /// assert_eq!(dir, TilingDirection::Vertical);
   /// ```
   pub fn inverse(&self) -> TilingDirection {
     match self {
@@ -31,7 +33,9 @@ impl TilingDirection {
   ///
   /// Example:
   /// ```
-  /// TilingDirection::from_direction(Direction::Left) // TilingDirection::Horizontal
+  /// # use wm::common::{Direction, TilingDirection};
+  /// let dir = TilingDirection::from_direction(&Direction::Left);
+  /// assert_eq!(dir, TilingDirection::Horizontal);
   /// ```
   pub fn from_direction(direction: &Direction) -> TilingDirection {
     match direction {
@@ -48,7 +52,13 @@ impl FromStr for TilingDirection {
   ///
   /// Example:
   /// ```
-  /// TilingDirection::from_str("horizontal") // TilingDirection::Horizontal
+  /// # use wm::common::TilingDirection;
+  /// # use std::str::FromStr;
+  /// let dir = TilingDirection::from_str("horizontal");
+  /// assert_eq!(dir.unwrap(), TilingDirection::Horizontal);
+  ///
+  /// let dir = TilingDirection::from_str("vertical");
+  /// assert_eq!(dir.unwrap(), TilingDirection::Vertical);
   /// ```
   fn from_str(unparsed: &str) -> anyhow::Result<Self> {
     match unparsed {

--- a/packages/wm/src/containers/commands/flatten_child_split_containers.rs
+++ b/packages/wm/src/containers/commands/flatten_child_split_containers.rs
@@ -8,7 +8,7 @@ use crate::containers::{
 /// parent container.
 ///
 /// For example:
-/// ```no_run,compile_fail,ignore
+/// ```ignore,compile_fail
 /// H[1 H[V[2, 3]]] -> H[1, 2, 3]
 /// H[1 H[2, 3]] -> H[1, 2, 3]
 /// H[V[1]] -> V[1]

--- a/packages/wm/src/containers/commands/flatten_child_split_containers.rs
+++ b/packages/wm/src/containers/commands/flatten_child_split_containers.rs
@@ -8,7 +8,7 @@ use crate::containers::{
 /// parent container.
 ///
 /// For example:
-/// ```
+/// ```no_run,compile_fail,ignore
 /// H[1 H[V[2, 3]]] -> H[1, 2, 3]
 /// H[1 H[2, 3]] -> H[1, 2, 3]
 /// H[V[1]] -> V[1]

--- a/packages/wm/src/containers/commands/flatten_split_container.rs
+++ b/packages/wm/src/containers/commands/flatten_split_container.rs
@@ -17,7 +17,7 @@ pub fn flatten_split_container(
   let parent = split_container.parent().context("No parent.")?;
 
   let updated_children =
-    split_container.children().into_iter().map(|child| {
+    split_container.children().into_iter().inspect(|child| {
       *child.borrow_parent_mut() = Some(parent.clone());
 
       // Resize tiling children to fit the size of the split container.
@@ -26,8 +26,6 @@ pub fn flatten_split_container(
           split_container.tiling_size() * tiling_child.tiling_size(),
         );
       }
-
-      child
     });
 
   let index = split_container.index();

--- a/packages/wm/src/containers/commands/focus_in_direction.rs
+++ b/packages/wm/src/containers/commands/focus_in_direction.rs
@@ -20,25 +20,25 @@ pub fn focus_in_direction(
     Container::TilingWindow(_) => {
       // If a suitable focus target isn't found in the current workspace,
       // attempt to find a workspace in the given direction.
-      tiling_focus_target(origin_container.clone(), &direction)?
+      tiling_focus_target(origin_container.clone(), direction)?
         .map_or_else(
-          || workspace_focus_target(origin_container, &direction, state),
+          || workspace_focus_target(origin_container, direction, state),
           |container| Ok(Some(container)),
         )?
     }
     Container::NonTilingWindow(ref non_tiling_window) => {
       match non_tiling_window.state() {
         WindowState::Floating(_) => {
-          floating_focus_target(origin_container, &direction)
+          floating_focus_target(origin_container, direction)
         }
         WindowState::Fullscreen(_) => {
-          workspace_focus_target(origin_container, &direction, state)?
+          workspace_focus_target(origin_container, direction, state)?
         }
         _ => None,
       }
     }
     Container::Workspace(_) => {
-      workspace_focus_target(origin_container, &direction, state)?
+      workspace_focus_target(origin_container, direction, state)?
     }
     _ => None,
   };

--- a/packages/wm/src/containers/commands/set_focused_descendant.rs
+++ b/packages/wm/src/containers/commands/set_focused_descendant.rs
@@ -27,6 +27,6 @@ pub fn set_focused_descendant(
       break;
     }
 
-    target = parent.into();
+    target = parent;
   }
 }

--- a/packages/wm/src/containers/root_container.rs
+++ b/packages/wm/src/containers/root_container.rs
@@ -41,8 +41,8 @@ pub struct RootContainerDto {
   child_focus_order: Vec<Uuid>,
 }
 
-impl RootContainer {
-  pub fn new() -> Self {
+impl Default for RootContainer {
+  fn default() -> Self {
     let root = RootContainerInner {
       id: Uuid::new_v4(),
       parent: None,
@@ -51,6 +51,12 @@ impl RootContainer {
     };
 
     Self(Rc::new(RefCell::new(root)))
+  }
+}
+
+impl RootContainer {
+  pub fn new() -> Self {
+    Self::default()
   }
 
   pub fn monitors(&self) -> Vec<Monitor> {

--- a/packages/wm/src/containers/traits/common_getters.rs
+++ b/packages/wm/src/containers/traits/common_getters.rs
@@ -127,7 +127,7 @@ pub trait CommonGetters {
 
     Box::new(std::iter::from_fn(move || {
       for child_id in child_focus_order.iter() {
-        if let Some(child) = self.child_by_id(&child_id) {
+        if let Some(child) = self.child_by_id(child_id) {
           return Some(child);
         }
       }
@@ -156,7 +156,7 @@ pub trait CommonGetters {
         for focus_child_id in
           current.borrow_child_focus_order().iter().rev()
         {
-          if let Some(focus_child) = current.child_by_id(&focus_child_id) {
+          if let Some(focus_child) = current.child_by_id(focus_child_id) {
             stack.push(focus_child);
           }
         }
@@ -297,9 +297,8 @@ impl Iterator for Ancestors {
   type Item = Container;
 
   fn next(&mut self) -> Option<Container> {
-    self.start.take().map(|container| {
+    self.start.take().inspect(|container| {
       self.start = container.parent().map(Into::into);
-      container
     })
   }
 }
@@ -313,7 +312,7 @@ impl Iterator for Descendants {
   type Item = Container;
 
   fn next(&mut self) -> Option<Container> {
-    while let Some(container) = self.stack.pop_front() {
+    if let Some(container) = self.stack.pop_front() {
       self.stack.extend(container.children());
       return Some(container);
     }

--- a/packages/wm/src/containers/traits/tiling_direction_getters.rs
+++ b/packages/wm/src/containers/traits/tiling_direction_getters.rs
@@ -22,7 +22,7 @@ pub trait TilingDirectionGetters: CommonGetters {
     &self,
     direction: &Direction,
   ) -> Option<TilingWindow> {
-    let child = self.child_in_direction(&direction)?;
+    let child = self.child_in_direction(direction)?;
 
     // Traverse further down if the child is a split container.
     match child {

--- a/packages/wm/src/main.rs
+++ b/packages/wm/src/main.rs
@@ -52,24 +52,24 @@ async fn main() -> Result<()> {
   let args = std::env::args().collect::<Vec<_>>();
   let app_command = AppCommand::parse_with_default(&args);
 
-  if let AppCommand::Start {
-    config_path,
-    verbosity,
-  } = app_command
-  {
-    let res = start_wm(config_path, verbosity).await;
+  match app_command {
+    AppCommand::Start {
+      config_path,
+      verbosity,
+    } => {
+      let res = start_wm(config_path, verbosity).await;
 
-    // If unable to start the WM, the error is fatal and a message dialog
-    // is shown.
-    if let Err(err) = &res {
-      error!("{:?}", err);
-      Platform::show_error_dialog("Fatal error", &err.to_string());
-    };
+      // If unable to start the WM, the error is fatal and a message dialog
+      // is shown.
+      if let Err(err) = &res {
+        error!("{:?}", err);
+        Platform::show_error_dialog("Fatal error", &err.to_string());
+      };
 
-    return res;
+      res
+    }
+    _ => start_cli(args).await,
   }
-
-  start_cli(args).await
 }
 
 async fn start_wm(

--- a/packages/wm/src/main.rs
+++ b/packages/wm/src/main.rs
@@ -46,8 +46,6 @@ mod workspaces;
 /// Conditionally starts the WM or runs a CLI command based on the given
 /// subcommand.
 #[tokio::main]
-// Clippy picks up on a return that is likely added by `#[tokio::main]`.
-#[allow(clippy::needless_return)]
 async fn main() -> Result<()> {
   let args = std::env::args().collect::<Vec<_>>();
   let app_command = AppCommand::parse_with_default(&args);

--- a/packages/wm/src/sys_tray.rs
+++ b/packages/wm/src/sys_tray.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, thread::JoinHandle, time::Duration};
+use std::{path::Path, thread::JoinHandle, time::Duration};
 
 use anyhow::Context;
 use tokio::sync::mpsc;
@@ -20,7 +20,7 @@ pub struct SystemTray {
 }
 
 impl SystemTray {
-  pub fn new(config_path: &PathBuf) -> anyhow::Result<Self> {
+  pub fn new(config_path: &Path) -> anyhow::Result<Self> {
     let (exit_tx, exit_rx) = mpsc::unbounded_channel();
     let (config_reload_tx, config_reload_rx) = mpsc::unbounded_channel();
     let config_dir = config_path
@@ -83,7 +83,7 @@ impl SystemTray {
         }
 
         // Run message loop with a delay of 16ms (60fps).
-        if let Err(_) = Platform::run_message_cycle() {
+        if Platform::run_message_cycle().is_err() {
           break;
         }
 

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -68,7 +68,7 @@ impl UserConfig {
       Self::create_sample(config_path.clone())?;
     }
 
-    let config_str = fs::read_to_string(&config_path)
+    let config_str = fs::read_to_string(config_path)
       .context("Unable to read config file.")?;
 
     // TODO: Improve error formatting of serde_yaml errors. Something
@@ -206,7 +206,7 @@ impl UserConfig {
       for event_type in &window_rule.on {
         window_rules_by_event
           .entry(event_type.clone())
-          .or_insert_with(|| Vec::new())
+          .or_insert_with(Vec::new)
           .push(window_rule.clone());
       }
     }
@@ -227,12 +227,12 @@ impl UserConfig {
 
     let pending_window_rules = self
       .window_rules_by_event
-      .get(&event)
+      .get(event)
       .unwrap_or(&Vec::new())
       .iter()
       .filter(|rule| {
         // Skip if window has already ran the rule.
-        if window.done_window_rules().contains(&rule) {
+        if window.done_window_rules().contains(rule) {
           return false;
         }
 
@@ -267,17 +267,16 @@ impl UserConfig {
 
   pub fn inactive_workspace_configs(
     &self,
-    active_workspaces: &Vec<Workspace>,
+    active_workspaces: &[Workspace],
   ) -> Vec<&WorkspaceConfig> {
     self
       .value
       .workspaces
       .iter()
       .filter(|config| {
-        active_workspaces
+        !active_workspaces
           .iter()
-          .find(|workspace| workspace.config().name == config.name)
-          .is_none()
+          .any(|workspace| workspace.config().name == config.name)
       })
       .collect()
   }
@@ -285,7 +284,7 @@ impl UserConfig {
   pub fn workspace_config_for_monitor(
     &self,
     monitor: &Monitor,
-    active_workspaces: &Vec<Workspace>,
+    active_workspaces: &[Workspace],
   ) -> Option<&WorkspaceConfig> {
     let inactive_configs =
       self.inactive_workspace_configs(active_workspaces);
@@ -303,7 +302,7 @@ impl UserConfig {
   /// don't have a monitor binding.
   pub fn next_inactive_workspace_config(
     &self,
-    active_workspaces: &Vec<Workspace>,
+    active_workspaces: &[Workspace],
   ) -> Option<&WorkspaceConfig> {
     let inactive_configs =
       self.inactive_workspace_configs(active_workspaces);
@@ -326,7 +325,7 @@ impl UserConfig {
       .position(|config| config.name == workspace_name)
   }
 
-  pub fn sort_workspaces(&self, workspaces: &mut Vec<Workspace>) {
+  pub fn sort_workspaces(&self, workspaces: &mut [Workspace]) {
     workspaces.sort_by_key(|workspace| {
       self.workspace_config_index(&workspace.config().name)
     });
@@ -531,7 +530,7 @@ pub struct BorderEffectConfig {
   pub color: Color,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct HideTitleBarEffectConfig {
   /// Whether to enable the effect.
@@ -551,9 +550,12 @@ pub struct CornerEffectConfig {
   pub style: CornerStyle,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(
+  Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, Default,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum CornerStyle {
+  #[default]
   Default,
   Square,
   Rounded,
@@ -659,17 +661,19 @@ fn default_window_rule_on() -> Vec<WindowRuleEvent> {
   vec![WindowRuleEvent::Manage, WindowRuleEvent::TitleChange]
 }
 
-impl Default for CornerStyle {
-  fn default() -> Self {
-    CornerStyle::Default
-  }
-}
+// Both are now derrived, left in case it is needed in the future
 
-impl Default for HideTitleBarEffectConfig {
-  fn default() -> Self {
-    HideTitleBarEffectConfig { enabled: false }
-  }
-}
+// impl Default for CornerStyle {
+//   fn default() -> Self {
+//     CornerStyle::Default
+//   }
+// }
+
+// impl Default for HideTitleBarEffectConfig {
+//   fn default() -> Self {
+//     HideTitleBarEffectConfig { enabled: false }
+//   }
+// }
 
 impl Default for CornerEffectConfig {
   fn default() -> Self {

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -661,20 +661,6 @@ fn default_window_rule_on() -> Vec<WindowRuleEvent> {
   vec![WindowRuleEvent::Manage, WindowRuleEvent::TitleChange]
 }
 
-// Both are now derrived, left in case it is needed in the future
-
-// impl Default for CornerStyle {
-//   fn default() -> Self {
-//     CornerStyle::Default
-//   }
-// }
-
-// impl Default for HideTitleBarEffectConfig {
-//   fn default() -> Self {
-//     HideTitleBarEffectConfig { enabled: false }
-//   }
-// }
-
 impl Default for CornerEffectConfig {
   fn default() -> Self {
     CornerEffectConfig {

--- a/packages/wm/src/windows/commands/move_window_in_direction.rs
+++ b/packages/wm/src/windows/commands/move_window_in_direction.rs
@@ -196,7 +196,7 @@ fn move_to_sibling_container(
         state
           .pending_sync
           .containers_to_redraw
-          .extend([target_parent.into(), parent.into()]);
+          .extend([target_parent.into(), parent]);
       }
     }
   };
@@ -252,7 +252,7 @@ fn move_to_workspace_in_direction(
     state
       .pending_sync
       .containers_to_redraw
-      .extend([workspace.into(), parent.into()]);
+      .extend([workspace.into(), parent]);
 
     state.pending_sync.cursor_jump = true;
   };
@@ -445,9 +445,9 @@ fn new_floating_position(
   // Calculate the distance the window should move based on the ratio of
   // the window's length to the monitor's length.
   let move_distance = match window_length as f32 / monitor_length as f32 {
-    x if x >= 0.0 && x < 0.2 => length_delta / 5,
-    x if x >= 0.2 && x < 0.4 => length_delta / 4,
-    x if x >= 0.4 && x < 0.6 => length_delta / 3,
+    x if (0.0..0.2).contains(&x) => length_delta / 5,
+    x if (0.2..0.4).contains(&x) => length_delta / 4,
+    x if (0.4..0.6).contains(&x) => length_delta / 3,
     _ => length_delta / 2,
   };
 

--- a/packages/wm/src/windows/commands/resize_window.rs
+++ b/packages/wm/src/windows/commands/resize_window.rs
@@ -78,8 +78,8 @@ pub fn resize_window(
 
   set_window_size(
     window.clone(),
-    target_width.map(|target_width| LengthValue::from_px(target_width)),
-    target_height.map(|target_height| LengthValue::from_px(target_height)),
+    target_width.map(LengthValue::from_px),
+    target_height.map(LengthValue::from_px),
     state,
   )?;
 

--- a/packages/wm/src/windows/commands/unmanage_window.rs
+++ b/packages/wm/src/windows/commands/unmanage_window.rs
@@ -22,8 +22,7 @@ pub fn unmanage_window(
   let ancestors = window.ancestors().take(3).collect::<Vec<_>>();
 
   // Get container to switch focus to after the window has been removed.
-  let focus_target =
-    state.focus_target_after_removal(&window.clone().into());
+  let focus_target = state.focus_target_after_removal(&window.clone());
 
   detach_container(window.clone().into())?;
 

--- a/packages/wm/src/windows/commands/update_window_state.rs
+++ b/packages/wm/src/windows/commands/update_window_state.rs
@@ -65,8 +65,7 @@ fn set_tiling(
     .or_else(|| {
       let focused_window = workspace
         .descendant_focus_order()
-        .filter(|descendant| descendant.is_tiling_window())
-        .next()?;
+        .find(|descendant| descendant.is_tiling_window())?;
 
       Some((focused_window.parent()?, focused_window.index() + 1))
     })

--- a/packages/wm/src/windows/non_tiling_window.rs
+++ b/packages/wm/src/windows/non_tiling_window.rs
@@ -54,7 +54,7 @@ impl NonTilingWindow {
     active_drag: Option<ActiveDrag>,
   ) -> Self {
     let window = NonTilingWindowInner {
-      id: id.unwrap_or_else(|| Uuid::new_v4()),
+      id: id.unwrap_or_else(Uuid::new_v4),
       parent: None,
       children: VecDeque::new(),
       child_focus_order: VecDeque::new(),

--- a/packages/wm/src/windows/tiling_window.rs
+++ b/packages/wm/src/windows/tiling_window.rs
@@ -62,7 +62,7 @@ impl TilingWindow {
     active_drag: Option<ActiveDrag>,
   ) -> Self {
     let window = TilingWindowInner {
-      id: id.unwrap_or_else(|| Uuid::new_v4()),
+      id: id.unwrap_or_else(Uuid::new_v4),
       parent: None,
       children: VecDeque::new(),
       child_focus_order: VecDeque::new(),

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -187,7 +187,7 @@ impl WmState {
     native_window: &NativeWindow,
   ) -> Option<Monitor> {
     self
-      .monitor_from_native(&Platform::nearest_monitor(&native_window))
+      .monitor_from_native(&Platform::nearest_monitor(native_window))
       .or(self.monitors().first().cloned())
   }
 
@@ -300,7 +300,7 @@ impl WmState {
         self
           .recent_workspace_name
           .as_ref()
-          .and_then(|name| self.workspace_by_name(&name)),
+          .and_then(|name| self.workspace_by_name(name)),
       ),
       WorkspaceTarget::NextActive => {
         let active_workspaces = self.sorted_workspaces(config);
@@ -446,7 +446,6 @@ impl WmState {
     self
       .root_container
       .self_and_descendants()
-      .into_iter()
       .find(|container| container.id() == id)
   }
 
@@ -474,12 +473,12 @@ impl WmState {
       .iter()
       .filter_map(|descendant| descendant.as_window_container().ok())
       .find(|descendant| {
-        match (descendant.state(), removed_window.state()) {
-          (WindowState::Tiling, WindowState::Tiling) => true,
-          (WindowState::Floating(_), WindowState::Floating(_)) => true,
-          (WindowState::Fullscreen(_), WindowState::Fullscreen(_)) => true,
-          _ => false,
-        }
+        matches!(
+          (descendant.state(), removed_window.state()),
+          (WindowState::Tiling, WindowState::Tiling)
+            | (WindowState::Floating(_), WindowState::Floating(_))
+            | (WindowState::Fullscreen(_), WindowState::Fullscreen(_))
+        )
       })
       .map(Into::into);
 
@@ -505,7 +504,7 @@ impl WmState {
       .filter(|descendant| {
         descendant
           .to_rect()
-          .map(|frame| frame.contains_point(&point))
+          .map(|frame| frame.contains_point(point))
           .unwrap_or(false)
       })
       .collect()
@@ -520,11 +519,13 @@ impl WmState {
         Container::Monitor(monitor) => Some(monitor),
         _ => None,
       })
-      .filter(|c| {
+      .find(|c| {
         let frame = c.to_rect();
-        frame.unwrap().contains_point(&position)
+        frame
+          .ok()
+          .map(|frame| frame.contains_point(position))
+          .unwrap_or(false)
       })
-      .next()
   }
 }
 

--- a/packages/wm/src/workspaces/commands/focus_workspace.rs
+++ b/packages/wm/src/workspaces/commands/focus_workspace.rs
@@ -11,7 +11,9 @@ use crate::{
   },
 };
 
-/// Focuses a workspace by a given target. This target can be a workspace
+/// Focuses a workspace by a given target.
+///
+/// This target can be a workspace
 /// name, the most recently focused workspace, the next workspace, the
 /// previous workspace, or the workspace in a given direction from the
 /// currently focused workspace.

--- a/packages/wm/src/workspaces/commands/focus_workspace.rs
+++ b/packages/wm/src/workspaces/commands/focus_workspace.rs
@@ -13,10 +13,9 @@ use crate::{
 
 /// Focuses a workspace by a given target.
 ///
-/// This target can be a workspace
-/// name, the most recently focused workspace, the next workspace, the
-/// previous workspace, or the workspace in a given direction from the
-/// currently focused workspace.
+/// This target can be a workspace name, the most recently focused
+/// workspace, the next workspace, the previous workspace, or the workspace
+/// in a given direction from the currently focused workspace.
 ///
 /// The workspace will be activated if it isn't already active.
 pub fn focus_workspace(


### PR DESCRIPTION
# Linting
Fixes most lint errors provided by clippy

Unused  variables / functions have not been fixed

Clippy detects `needless_return` on both `main` functions, which I believe is caused by `#[tokio::main]`, so these have been supressed.

# Doctests
The following are no longer run:
- `wm\src\containers\commands\flatten_child_split_containers.rs:11` : `flatten_child_split_containers` has been ignored
- `wm\src\common\platform\platform.rs:340`: `parse_command` has been set to `no_run` as it requires files to exist on the test machine.

The following have been fixed so that they can be compiled and ran:
- `wm\src\common\tiling_direction.rs:19`: `inverse`
- `wm\src\common\tiling_direction.rs:35`: `from_direction`
- `wm\src\common\tiling_direction.rs:54`: `from_str`
- `wm\src\common\direction.rs:19` : `inverse`
- `wm\src\common\direction.rs:40` : `from_str`
- `wm\src\common\length_value.rs:52`: `from_str`