### PR TITLE
fix: regression in layouting with taskbar alignments

### DIFF
--- a/packages/wm/src/common/rect.rs
+++ b/packages/wm/src/common/rect.rs
@@ -125,32 +125,6 @@ impl Rect {
     }
   }
 
-  pub fn apply_delta(
-    &self,
-    delta: &RectDelta,
-    scale_factor: Option<f32>,
-  ) -> Self {
-    Self::from_ltrb(
-      self.left - delta.left.to_px(self.width(), scale_factor),
-      self.top - delta.top.to_px(self.height(), scale_factor),
-      self.right + delta.right.to_px(self.width(), scale_factor),
-      self.bottom + delta.bottom.to_px(self.height(), scale_factor),
-    )
-  }
-
-  pub fn apply_inverse_delta(
-    &self,
-    delta: &RectDelta,
-    scale_factor: Option<f32>,
-  ) -> Self {
-    Self::from_ltrb(
-      self.left + delta.left.to_px(self.width(), scale_factor),
-      self.top + delta.top.to_px(self.height(), scale_factor),
-      self.right - delta.right.to_px(self.width(), scale_factor),
-      self.bottom - delta.bottom.to_px(self.height(), scale_factor),
-    )
-  }
-
   // Gets whether the x-coordinate overlaps with the x-coordinate of the
   // other rect.
   pub fn has_overlap_x(&self, other: &Rect) -> bool {


### PR DESCRIPTION
# Fix regression in layouting with taskbar alignments
This PR fixes #790 and #640 issues. Currently GlazeWM doesn't take in-account the delta offsets of the working area of the monitor, thus graphical issues occur in the latest version of GlazeWM. This PR should fix it.

**Note**: I've tested **StartAllBack** and **Windhawk's top taskbar mod** by @m417z , but I am pretty confident **ExplorerPatcher** would also work due to the nature of **StartAllBack**'s use of classic taskbar.

# Before (this issue persists since at least GlazeWM 3.4.0):

https://github.com/user-attachments/assets/49232096-19f2-467a-a81d-8d88800ff994


https://github.com/user-attachments/assets/12377265-a8ef-4295-8463-ee648e9ff092

# After:

https://github.com/user-attachments/assets/7c464d72-37ea-48bb-b2e3-ce8c375e8b33


https://github.com/user-attachments/assets/b71bb32e-8712-44e0-bc70-8ef2a52aad97