### PR TITLE
fix: regression in layouting with fullscreen state

### DIFF
--- a/packages/wm/src/common/events/handle_window_location_changed.rs
+++ b/packages/wm/src/common/events/handle_window_location_changed.rs
@@ -5,7 +5,7 @@ use crate::{
   common::{platform::NativeWindow, Rect},
   containers::{
     commands::{flatten_split_container, move_container_within_tree},
-    traits::{CommonGetters, PositionGetters},
+    traits::CommonGetters,
     WindowContainer,
   },
   try_warn,
@@ -26,6 +26,7 @@ pub fn handle_window_location_changed(
 
   // Update the window's state to be fullscreen or toggled from fullscreen.
   if let Some(window) = found_window {
+
     let old_frame_position = window.native().frame_position()?;
     let frame_position =
       try_warn!(window.native().refresh_frame_position());
@@ -49,21 +50,13 @@ pub fn handle_window_location_changed(
         config,
       )?;
     }
-
-    let monitor_rect = if config.has_outer_gaps() {
-      nearest_monitor.native().working_rect()?.clone()
-    } else {
-      nearest_monitor.to_rect()?
-    };
-
-    let is_fullscreen = window.native().is_fullscreen(&monitor_rect)?;
-
     match window.state() {
       WindowState::Fullscreen(fullscreen_state) => {
-        // A fullscreen window that gets minimized can hit this arm, so
+        // A full working area window that gets minimized can hit this arm, so
         // ignore such events and let it be handled by the handler for
         // `PlatformEvent::WindowMinimized` instead.
-        if !(is_fullscreen || is_maximized || !is_minimized) {
+        let is_full_work_area = window.native().is_full_work_area(&nearest_monitor.native())?;
+        if !(is_full_work_area || is_maximized) && !is_minimized {
           info!("Window restored");
 
           let target_state = window
@@ -92,9 +85,10 @@ pub fn handle_window_location_changed(
       }
       _ => {
         // Update the window to be fullscreen if there's been a change in
-        // maximized state or if the window is now fullscreen.
-        if (is_maximized && old_is_maximized != is_maximized)
-          || is_fullscreen
+        // maximized state
+        let is_fullscreen = window.native()
+          .is_fullscreen(&nearest_monitor.native())?;
+        if (is_maximized && old_is_maximized != is_maximized) || is_fullscreen
         {
           info!("Window fullscreened");
 

--- a/packages/wm/src/common/platform/native_window.rs
+++ b/packages/wm/src/common/platform/native_window.rs
@@ -40,6 +40,8 @@ use crate::{
   windows::WindowState,
 };
 
+use super::NativeMonitor;
+
 #[derive(Debug, Clone)]
 pub struct NativeWindow {
   pub handle: isize,
@@ -258,26 +260,26 @@ impl NativeWindow {
     self.has_window_style(WS_THICKFRAME)
   }
 
-  /// Whether the window is fullscreen.
-  ///
-  /// Returns `false` if the window is maximized.
-  pub fn is_fullscreen(
-    &self,
-    monitor_rect: &Rect,
-  ) -> anyhow::Result<bool> {
-    if self.is_maximized()? {
-      return Ok(false);
-    }
 
-    let position = self.frame_position()?;
+  fn is_fullscreen_rect(&self, rect: &Rect) -> anyhow::Result<bool> {
+    let window_position = self.frame_position()?;
 
-    // Allow for 1px of leeway around edges of monitor.
     Ok(
-      position.left <= monitor_rect.left + 1
-        && position.top <= monitor_rect.top + 1
-        && position.right >= monitor_rect.right - 1
-        && position.bottom >= monitor_rect.bottom - 1,
+      window_position.left <= rect.left &&
+      window_position.top <= rect.top &&
+      window_position.right >= rect.right &&
+      window_position.bottom >= rect.bottom
     )
+  }
+
+  // Whether the window fully fills work area of specified monitor.
+  pub fn is_full_work_area(&self, monitor: &NativeMonitor) -> anyhow::Result<bool> {
+    return Ok(self.is_fullscreen_rect(monitor.working_rect()?)?);
+  }
+
+  /// Whether the window is fullscreen on specified monitor.
+  pub fn is_fullscreen(&self, monitor: &NativeMonitor) -> anyhow::Result<bool> {
+    return Ok(self.is_fullscreen_rect(monitor.rect()?)?);
   }
 
   pub fn set_foreground(&self) -> anyhow::Result<()> {

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -334,16 +334,6 @@ impl UserConfig {
       self.workspace_config_index(&workspace.config().name)
     });
   }
-
-  pub fn has_outer_gaps(&self) -> bool {
-    let outer_gap = &self.value.gaps.outer_gap;
-
-    // Allow for 1px/1% of leeway.
-    outer_gap.bottom.amount > 1.0
-      || outer_gap.left.amount > 1.0
-      || outer_gap.right.amount > 1.0
-      || outer_gap.top.amount > 1.0
-  }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/packages/wm/src/windows/commands/manage_window.rs
+++ b/packages/wm/src/windows/commands/manage_window.rs
@@ -182,13 +182,7 @@ fn window_state_to_create(
     return Ok(WindowState::Minimized);
   }
 
-  let monitor_rect = if config.has_outer_gaps() {
-    nearest_monitor.native().working_rect()?.clone()
-  } else {
-    nearest_monitor.to_rect()?
-  };
-
-  if native_window.is_fullscreen(&monitor_rect)? {
+  if native_window.is_fullscreen(&nearest_monitor.native())? {
     return Ok(WindowState::Fullscreen(
       config
         .value

--- a/packages/wm/src/windows/non_tiling_window.rs
+++ b/packages/wm/src/windows/non_tiling_window.rs
@@ -131,7 +131,11 @@ impl PositionGetters for NonTilingWindow {
   fn to_rect(&self) -> anyhow::Result<Rect> {
     match self.state() {
       WindowState::Fullscreen(_) => {
-        self.monitor().context("No monitor.")?.to_rect()
+        let native_monitor = self.monitor().context("No monitor.")?.native();
+        Ok(match self.native().is_fullscreen(&native_monitor)? {
+          true => native_monitor.rect()?.clone(),
+          false => native_monitor.working_rect()?.clone()
+        })
       }
       _ => Ok(self.floating_placement()),
     }


### PR DESCRIPTION
# Fix regression in layouting with fullscreen state
This PR fixes an issue where window's fullscreen state would overflow under existing elements in the desktop. Currently GlazeWM doesn't take in-account the delta offsets of the working area of the monitor when calculating fullscreen state window size, thus graphical issues occur in the latest version of GlazeWM. This PR should fix it.

**Note**: This PR works best with #836 PR, since it also fixes issues with graphical issues, related to the delta offsets of working area.

# Before:

https://github.com/user-attachments/assets/f8c598a5-0f3d-4760-becc-b49668ec4ed0

# After:

https://github.com/user-attachments/assets/c81e7765-f880-4d6b-b698-a4a4c85bd652

