### PR TITLE
fix: window positioning regression when windows are opened simultaneously

### DIFF
--- a/packages/wm/src/common/platform/native_window.rs
+++ b/packages/wm/src/common/platform/native_window.rs
@@ -595,9 +595,6 @@ impl NativeWindow {
       _ => HWND_NOTOPMOST,
     };
 
-    // Whether to show or hide the window.
-    self.set_visible(is_visible, hide_method)?;
-
     match state {
       WindowState::Minimized => {
         if !self.is_minimized()? {
@@ -657,6 +654,9 @@ impl NativeWindow {
         }
       }
     };
+
+    // Whether to show or hide the window.
+    self.set_visible(is_visible, hide_method)?;
 
     Ok(())
   }


### PR DESCRIPTION
Regression found by @DreamMaoMao in #792

https://github.com/user-attachments/assets/c167e9e4-b85c-4d09-83bd-1d613ac73145

