### PR TITLE
feat: revert to keybindings for prev/next active workspace in sample config

### DIFF
--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -250,6 +250,12 @@ keybindings:
   - commands: ['focus --prev-workspace']
     bindings: ['alt+a']
 
+  # Focus the next/previous active workspace defined in `workspaces` config.
+  - commands: ['focus --next-active-workspace']
+    bindings: ['alt+e']
+  - commands: ['focus --prev-active-workspace']
+    bindings: ['alt+b']
+
   # Focus the workspace that last had focus.
   - commands: ['focus --recent-workspace']
     bindings: ['alt+d']

--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -244,17 +244,11 @@ keybindings:
   - commands: ['shell-exec cmd']
     bindings: ['alt+enter']
 
-  # Focus the next/previous workspace defined in `workspaces` config.
-  - commands: ['focus --next-workspace']
-    bindings: ['alt+s']
-  - commands: ['focus --prev-workspace']
-    bindings: ['alt+a']
-
   # Focus the next/previous active workspace defined in `workspaces` config.
   - commands: ['focus --next-active-workspace']
-    bindings: ['alt+e']
+    bindings: ['alt+s']
   - commands: ['focus --prev-active-workspace']
-    bindings: ['alt+b']
+    bindings: ['alt+a']
 
   # Focus the workspace that last had focus.
   - commands: ['focus --recent-workspace']


### PR DESCRIPTION
Notice many people asking how this key is bound, and it is a common feature, so suggest adding them to the default sample configuration