### PR TITLE
fix: ignore resize events and skip IPC emissions while WM is paused

### DIFF
--- a/packages/wm/src/common/commands/platform_sync.rs
+++ b/packages/wm/src/common/commands/platform_sync.rs
@@ -22,6 +22,13 @@ pub fn platform_sync(
   state: &mut WmState,
   config: &UserConfig,
 ) -> anyhow::Result<()> {
+  // Skip platform sync when the WM is paused.
+  if state.is_paused {
+    // Clear containers to redraw to avoid leaking memory.
+    state.pending_sync.containers_to_redraw.clear();
+    return Ok(());
+  }
+
   if !state.pending_sync.containers_to_redraw.is_empty() {
     redraw_containers(state, config)?;
     state.pending_sync.containers_to_redraw.clear();

--- a/packages/wm/src/common/commands/toggle_pause.rs
+++ b/packages/wm/src/common/commands/toggle_pause.rs
@@ -1,17 +1,12 @@
-use crate::{
-  user_config::{UserConfig, WindowRuleEvent},
-  windows::{commands::run_window_rules, traits::WindowGetters},
-  wm_event::WmEvent,
-  wm_state::WmState,
-};
+use crate::{wm_event::WmEvent, wm_state::WmState};
 
 /// Pauses or unpauses the WM.
 pub fn toggle_pause(state: &mut WmState) -> anyhow::Result<()> {
-  let new_paused_state = !state.paused;
-  state.paused = new_paused_state;
+  let new_paused_state = !state.is_paused;
+  state.is_paused = new_paused_state;
 
+  // Redraw full container tree on unpause.
   if !new_paused_state {
-    // Redraw full container tree.
     let root_container = state.root_container.clone();
     state
       .pending_sync
@@ -20,7 +15,7 @@ pub fn toggle_pause(state: &mut WmState) -> anyhow::Result<()> {
   }
 
   state.emit_event(WmEvent::PauseChanged {
-    paused: new_paused_state,
+    is_paused: new_paused_state,
   });
 
   Ok(())

--- a/packages/wm/src/common/events/handle_window_moved_or_resized_end.rs
+++ b/packages/wm/src/common/events/handle_window_moved_or_resized_end.rs
@@ -55,6 +55,11 @@ pub fn handle_window_moved_or_resized_end(
         }
       }
       WindowContainer::TilingWindow(window) => {
+        // Don't update state on resize events if the WM is paused.
+        if state.is_paused {
+          return Ok(());
+        }
+
         info!("Tiling window resized");
 
         let parent = window.parent().context("No parent.")?;

--- a/packages/wm/src/common/platform/event_window.rs
+++ b/packages/wm/src/common/platform/event_window.rs
@@ -71,7 +71,6 @@ static LAST_MOUSE_EVENT_TIME: AtomicU64 = AtomicU64::new(0);
 pub struct EventWindow {
   keyboard_hook: Arc<KeyboardHook>,
   window_thread: Option<JoinHandle<anyhow::Result<()>>>,
-  paused: bool,
 }
 
 impl EventWindow {
@@ -133,7 +132,6 @@ impl EventWindow {
     Ok(Self {
       keyboard_hook,
       window_thread: Some(window_thread),
-      paused: false,
     })
   }
 
@@ -141,12 +139,9 @@ impl EventWindow {
     &mut self,
     keybindings: &Vec<KeybindingConfig>,
     enable_mouse_events: bool,
-    paused: bool,
   ) {
-    self.keyboard_hook.update(keybindings, paused);
-    ENABLE_MOUSE_EVENTS
-      .store(enable_mouse_events && !paused, Ordering::Relaxed);
-    self.paused = paused;
+    self.keyboard_hook.update(keybindings);
+    ENABLE_MOUSE_EVENTS.store(enable_mouse_events, Ordering::Relaxed);
   }
 
   /// Destroys the event window and stops the message loop.

--- a/packages/wm/src/common/platform/keyboard_hook.rs
+++ b/packages/wm/src/common/platform/keyboard_hook.rs
@@ -1,6 +1,6 @@
 use std::{
   collections::HashMap,
-  sync::{atomic::AtomicBool, Arc, Mutex, OnceLock},
+  sync::{Arc, Mutex, OnceLock},
 };
 
 use tokio::sync::mpsc;
@@ -17,10 +17,7 @@ use windows::Win32::{
 };
 
 use super::PlatformEvent;
-use crate::{
-  app_command::InvokeCommand, common::platform::com,
-  user_config::KeybindingConfig,
-};
+use crate::user_config::KeybindingConfig;
 
 /// Global instance of `KeyboardHook`.
 ///
@@ -55,8 +52,6 @@ pub struct KeyboardHook {
   /// final key in a key combination.
   keybindings_by_trigger_key:
     Arc<Mutex<HashMap<u16, Vec<ActiveKeybinding>>>>,
-
-  paused: AtomicBool,
 }
 
 impl KeyboardHook {
@@ -71,7 +66,6 @@ impl KeyboardHook {
       keybindings_by_trigger_key: Arc::new(Mutex::new(
         Self::keybindings_by_trigger_key(keybindings),
       )),
-      paused: AtomicBool::new(false),
     });
 
     KEYBOARD_HOOK
@@ -92,13 +86,9 @@ impl KeyboardHook {
     Ok(())
   }
 
-  pub fn update(&self, keybindings: &Vec<KeybindingConfig>, paused: bool) {
+  pub fn update(&self, keybindings: &Vec<KeybindingConfig>) {
     *self.keybindings_by_trigger_key.lock().unwrap() =
       Self::keybindings_by_trigger_key(keybindings);
-
-    self
-      .paused
-      .store(paused, std::sync::atomic::Ordering::SeqCst);
   }
 
   /// Stops the low-level keyboard hook.
@@ -362,21 +352,6 @@ impl KeyboardHook {
           });
 
         if has_modifier_keys_to_reject {
-          return false;
-        }
-
-        // Is the WM paused and the keybinding does not a contain toggle
-        // pause command
-        if self.paused.load(std::sync::atomic::Ordering::SeqCst)
-          && longest_keybinding
-            .config
-            .commands
-            .iter()
-            .find(|command| {
-              matches!(command, InvokeCommand::WmTogglePause)
-            })
-            .is_none()
-        {
           return false;
         }
 

--- a/packages/wm/src/ipc_server.rs
+++ b/packages/wm/src/ipc_server.rs
@@ -325,7 +325,7 @@ impl IpcServer {
           })
         }
         QueryCommand::Paused => {
-          ClientResponseData::Paused(wm.state.paused)
+          ClientResponseData::Paused(wm.state.is_paused)
         }
       },
       AppCommand::Command {

--- a/packages/wm/src/main.rs
+++ b/packages/wm/src/main.rs
@@ -170,7 +170,7 @@ async fn start_wm(
           event_listener.update(
             &config,
             &wm.state.binding_modes,
-            wm.state.paused,
+            wm.state.is_paused,
           );
         }
 

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -95,12 +95,7 @@ impl WindowManager {
       }
     }?;
 
-    // Skip platform sync when paused.
-    if !state.paused {
-      platform_sync(state, config)?;
-    }
-
-    Ok(())
+    platform_sync(state, config)
   }
 
   pub fn process_commands(

--- a/packages/wm/src/wm_event.rs
+++ b/packages/wm/src/wm_event.rs
@@ -61,6 +61,6 @@ pub enum WmEvent {
     updated_workspace: ContainerDto,
   },
   PauseChanged {
-    paused: bool,
+    is_paused: bool,
   },
 }

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -55,7 +55,7 @@ pub struct WmState {
   pub ignored_windows: Vec<NativeWindow>,
 
   /// Whether the WM is paused.
-  pub paused: bool,
+  pub is_paused: bool,
 
   /// Whether the initial state has been populated.
   has_initialized: bool,
@@ -101,7 +101,7 @@ impl WmState {
       unmanaged_or_minimized_timestamp: None,
       binding_modes: Vec::new(),
       ignored_windows: Vec::new(),
-      paused: false,
+      is_paused: false,
       has_initialized: false,
       event_tx,
       exit_tx,
@@ -430,11 +430,12 @@ impl WmState {
 
   /// Emits a WM event through an MSPC channel.
   ///
-  /// Does not emit events while the WM is populating initial state. This
-  /// is to prevent events (e.g. workspace activation events) from being
-  /// emitted via IPC server before the initial state is prepared.
+  /// Does not emit events while the WM is paused or populating initial
+  /// state. This is to prevent events (e.g. workspace activation events)
+  /// from being emitted via IPC server before the initial state is
+  /// prepared.
   pub fn emit_event(&self, event: WmEvent) {
-    if self.has_initialized {
+    if self.has_initialized && !self.is_paused {
       if let Err(err) = self.event_tx.send(event) {
         warn!("Failed to send event: {}", err);
       }


### PR DESCRIPTION
Small follow-up to #828 @michidk 