### PR TITLE
fix: `move-workspace` moves cursor if `cursor_jump` is enabled

### DIFF
--- a/packages/wm/src/workspaces/commands/move_workspace_in_direction.rs
+++ b/packages/wm/src/workspaces/commands/move_workspace_in_direction.rs
@@ -51,6 +51,7 @@ pub fn move_workspace_in_direction(
       );
     }
 
+    state.pending_sync.cursor_jump = true;
     state
       .pending_sync
       .containers_to_redraw


### PR DESCRIPTION
Closes #859