### PR TITLE
fix: pause IPC event not emitting

### DIFF
--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -435,7 +435,10 @@ impl WmState {
   /// from being emitted via IPC server before the initial state is
   /// prepared.
   pub fn emit_event(&self, event: WmEvent) {
-    if self.has_initialized && !self.is_paused {
+    if self.has_initialized
+      && (!self.is_paused
+        || matches!(event, WmEvent::PauseChanged { is_paused: _ }))
+    {
       if let Err(err) = self.event_tx.send(event) {
         warn!("Failed to send event: {}", err);
       }


### PR DESCRIPTION
Fixes the pause IPC not working:

```sh
PS Microsoft.PowerShell.Core\FileSystem::\\wsl.localhost\Arch\home\michi\dev\glazewm\target\x86_64-pc-windows-gnu\debug> ./glazewm sub -e pause_changed
{"data":{"eventType":"pause_changed","isPaused":false},"error":null,"subscriptionId":"bf8e2089-487a-4cc9-8846-f5c9e7b17b82","success":true}
{"data":{"eventType":"pause_changed","isPaused":false},"error":null,"subscriptionId":"bf8e2089-487a-4cc9-8846-f5c9e7b17b82","success":true}
{"data":{"eventType":"pause_changed","isPaused":false},"error":null,"subscriptionId":"bf8e2089-487a-4cc9-8846-f5c9e7b17b82","success":true}
```