### PR TITLE
fix: Window effects don't update on focus switch

### DIFF
--- a/packages/wm/src/events/handle_window_focused.rs
+++ b/packages/wm/src/events/handle_window_focused.rs
@@ -26,7 +26,6 @@ pub fn handle_window_focused(
     // 1. Window is being hidden by the WM.
     // 2. Focus is already set to the WM's focused container.
     if window.display_state() == DisplayState::Hiding
-      || state.focused_container() == Some(window.clone().into())
     {
       return Ok(());
     }
@@ -76,7 +75,7 @@ pub fn handle_window_focused(
 
     state
       .pending_sync
-      .queue_focused_effect_update()
+      .queue_all_effects_update()
       .queue_workspace_to_reorder(workspace);
   }
 


### PR DESCRIPTION
Fix for window effects not updating when window focus changes.

At HEAD window effects such as border colors are not updating when window focus changes.

Issue seems? to be that the `handle_window_focused` is called after the focused container of `state` is updated to the new window.
