### PR TITLE
feat: change monitor focus with `general.focus_follows_cursor`

### DIFF
--- a/packages/wm-platform/src/platform.rs
+++ b/packages/wm-platform/src/platform.rs
@@ -160,6 +160,19 @@ impl Platform {
     Ok(NativeWindow::new(handle.0))
   }
 
+  pub fn monitor_from_point(
+    point: &Point,
+  ) -> anyhow::Result<NativeMonitor> {
+    let monitors = native_monitor::available_monitors()?;
+    monitors
+      .iter()
+      .find_map(|monitor| {
+        let rect = monitor.rect().ok()?;
+        rect.contains_point(point).then(|| monitor.clone())
+      })
+      .context("Monitor not found")
+  }
+
   /// Gets the mouse position in screen space.
   pub fn mouse_position() -> anyhow::Result<Point> {
     let mut point = POINT { x: 0, y: 0 };

--- a/packages/wm-platform/src/platform.rs
+++ b/packages/wm-platform/src/platform.rs
@@ -160,19 +160,6 @@ impl Platform {
     Ok(NativeWindow::new(handle.0))
   }
 
-  pub fn monitor_from_point(
-    point: &Point,
-  ) -> anyhow::Result<NativeMonitor> {
-    let monitors = native_monitor::available_monitors()?;
-    monitors
-      .iter()
-      .find_map(|monitor| {
-        let rect = monitor.rect().ok()?;
-        rect.contains_point(point).then(|| monitor.clone())
-      })
-      .context("Monitor not found")
-  }
-
   /// Gets the mouse position in screen space.
   pub fn mouse_position() -> anyhow::Result<Point> {
     let mut point = POINT { x: 0, y: 0 };

--- a/packages/wm/src/events/handle_mouse_move.rs
+++ b/packages/wm/src/events/handle_mouse_move.rs
@@ -13,7 +13,12 @@ pub fn handle_mouse_move(
 ) -> anyhow::Result<()> {
   // Ignore event if left/right-click is down. Otherwise, this causes focus
   // to jitter when a window is being resized by its drag handles.
-  if event.is_mouse_down || !config.value.general.focus_follows_cursor {
+  // Also ignore if the OS focused window isn't the same as the WM's
+  // focused window.
+  if event.is_mouse_down
+    || !state.is_focus_synced
+    || !config.value.general.focus_follows_cursor
+  {
     return Ok(());
   }
 

--- a/packages/wm/src/events/handle_mouse_move.rs
+++ b/packages/wm/src/events/handle_mouse_move.rs
@@ -30,6 +30,23 @@ pub fn handle_mouse_move(
       set_focused_descendant(&window.as_container(), None);
       state.pending_sync.queue_focus_change();
     }
+  } else {
+    // Focus the monitor if no window is under the cursor.
+    let monitor_under_cursor = Platform::monitor_from_point(&event.point)
+      .map(|workspace| state.monitor_from_native(&workspace))?
+      .context("No monitor under cursor.")?;
+
+    let currently_focused_monitor = state
+      .focused_container()
+      .context("No focused container.")?
+      .monitor()
+      .context("Focused container has no monitor.")?;
+
+    // Avoid setting focus to the same monitor.
+    if monitor_under_cursor.id() != currently_focused_monitor.id() {
+      set_focused_descendant(&monitor_under_cursor.as_container(), None);
+      state.pending_sync.queue_focus_change();
+    }
   }
 
   Ok(())

--- a/packages/wm/src/events/handle_mouse_move.rs
+++ b/packages/wm/src/events/handle_mouse_move.rs
@@ -32,19 +32,19 @@ pub fn handle_mouse_move(
     }
   } else {
     // Focus the monitor if no window is under the cursor.
-    let monitor_under_cursor = Platform::monitor_from_point(&event.point)
-      .map(|workspace| state.monitor_from_native(&workspace))?
+    let cursor_monitor = state
+      .monitor_at_point(&event.point)
       .context("No monitor under cursor.")?;
 
-    let currently_focused_monitor = state
+    let focused_monitor = state
       .focused_container()
       .context("No focused container.")?
       .monitor()
       .context("Focused container has no monitor.")?;
 
     // Avoid setting focus to the same monitor.
-    if monitor_under_cursor.id() != currently_focused_monitor.id() {
-      set_focused_descendant(&monitor_under_cursor.as_container(), None);
+    if cursor_monitor.id() != focused_monitor.id() {
+      set_focused_descendant(&cursor_monitor.as_container(), None);
       state.pending_sync.queue_focus_change();
     }
   }

--- a/packages/wm/src/events/handle_window_focused.rs
+++ b/packages/wm/src/events/handle_window_focused.rs
@@ -87,6 +87,7 @@ pub fn handle_window_focused(
     // Run window rules for focus events.
     run_window_rules(window, &WindowRuleEvent::Focus, state, config)?;
 
+    state.is_focus_synced = true;
     state.pending_sync.queue_workspace_to_reorder(workspace);
   }
 

--- a/packages/wm/src/events/handle_window_focused.rs
+++ b/packages/wm/src/events/handle_window_focused.rs
@@ -8,7 +8,7 @@ use crate::{
     container::set_focused_descendant, window::run_window_rules,
     workspace::focus_workspace,
   },
-  models::{Container, WorkspaceTarget},
+  models::WorkspaceTarget,
   traits::{CommonGetters, WindowGetters},
   user_config::UserConfig,
   wm_state::WmState,
@@ -23,13 +23,20 @@ pub fn handle_window_focused(
   let focused_container =
     state.focused_container().context("No focused container.")?;
 
+  // Update the focus sync state. If the OS focused window is not same as
+  // the WM's focused container, then the focus is not synced.
+  state.is_focus_synced = match focused_container.as_window_container() {
+    Ok(window) => *window.native() == *native_window,
+    _ => Platform::desktop_window() == *native_window,
+  };
+
   // Handle overriding focus on close/minimize. After a window is closed
   // or minimized, the OS or the closed application might automatically
   // switch focus to a different window. To force focus to go to the WM's
   // target focus container, we reassign any focus events 100ms after
   // close/minimize. This will cause focus to briefly flicker to the OS
   // focus target and then to the WM's focus target.
-  if should_override_focus(&focused_container, native_window, state) {
+  if should_override_focus(state) {
     state.pending_sync.queue_focus_change();
     return Ok(());
   }
@@ -54,6 +61,7 @@ pub fn handle_window_focused(
 
     // Native focus has been synced to the WM's focused container.
     if focused_container == window.clone().into() {
+      state.is_focus_synced = true;
       state.pending_sync.queue_workspace_to_reorder(workspace);
       return Ok(());
     }
@@ -86,19 +94,10 @@ pub fn handle_window_focused(
 }
 
 /// Returns true if focus should be reassigned to the WM's focus container.
-fn should_override_focus(
-  focused_container: &Container,
-  native_window: &NativeWindow,
-  state: &WmState,
-) -> bool {
+fn should_override_focus(state: &WmState) -> bool {
   let has_recent_unmanage = state
     .unmanaged_or_minimized_timestamp
     .is_some_and(|time| time.elapsed().as_millis() < 100);
 
-  let has_correct_focus = match focused_container.as_window_container() {
-    Ok(window) => *window.native() == *native_window,
-    _ => Platform::desktop_window() == *native_window,
-  };
-
-  has_recent_unmanage && !has_correct_focus
+  has_recent_unmanage && !state.is_focus_synced
 }

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -58,6 +58,9 @@ pub struct WmState {
   /// Whether the WM is paused.
   pub is_paused: bool,
 
+  /// Whether the OS focused window is the same as the WM focused window.
+  pub is_focus_synced: bool,
+
   /// Whether the initial state has been populated.
   has_initialized: bool,
 
@@ -82,6 +85,7 @@ impl WmState {
       binding_modes: Vec::new(),
       ignored_windows: Vec::new(),
       is_paused: false,
+      is_focus_synced: false,
       has_initialized: false,
       event_tx,
       exit_tx,
@@ -129,6 +133,7 @@ impl WmState {
       .context("Failed to get container to focus.")?;
 
     set_focused_descendant(&container_to_focus, None);
+    self.is_focus_synced = true;
 
     self
       .pending_sync


### PR DESCRIPTION
This PR makes the general.focus_follows_cursor code focus the monitor that the cursor is on when there isn't a window to focus. This makes it so if you focus monitor 1, move your cursor to monitor 2 and open a program, the program will open on monitor 2 and not on monitor 1.

Before:

https://github.com/user-attachments/assets/bd260c32-8add-442c-b518-0e5a4ff14aa9

After:

https://github.com/user-attachments/assets/22ce7026-f1fb-43ee-8a92-85125c3127a3


This has been annoying me for a while, so I decided to fix it...

I don't know if it would've been better to make it focus the workspace under the cursor or not. Since there can only be one workspace displayed per monitor, I chose to make it focus the monitor.
Just let me know if you think it would be better to focus the workspace instead!