### PR TITLE
fix: fix truncated window title log panic

### DIFF
--- a/packages/wm/src/models/container.rs
+++ b/packages/wm/src/models/container.rs
@@ -222,7 +222,12 @@ impl std::fmt::Display for WindowContainer {
 
     // Truncate title if longer than 20 chars.
     let title = if title.len() > 20 {
-      format!("{}...", &title[..17])
+      format!(
+        "{}...",
+        &title
+          /* Find the first safe char boundary. */
+          [..(0..=17).rfind(|n| title.is_char_boundary(*n)).unwrap_or(0)]
+      )
     } else {
       title
     };


### PR DESCRIPTION
<!--
Before submitting a PR, follow this checklist:

1. Give the PR a descriptive title.

  Examples of good titles:
    - fix: fix race condition in message loop
    - docs: update readme with new demo gif
    - feat: add new `general.focus_follows_mouse` config option

  Examples of bad titles:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR description, e.g. closes #123.
3. Propose your changes as a draft PR if your work is still in progress.
-->
Fixes a panic that only happens in development. If a window title contains an emoji or something right where it gets truncated by `(WindowContainer as std::fmt::Display)::fmt`, a panic will occur. 
Truncating a `&str` can cause it to contain invalid utf-8, which is not allowed in Rust strings. This PR adds some code to make sure it finds a safe character boundary before truncating.
Based on https://users.rust-lang.org/t/truncate-str-to-n-utf-8-chars/86626/14