### PR TITLE
chore: add vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.check.command": "clippy",
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,4 +2,6 @@
   "rust-analyzer.check.command": "clippy",
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
   "rust-analyzer.check.command": "clippy",
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
 }

--- a/packages/wm-platform/src/event_window.rs
+++ b/packages/wm-platform/src/event_window.rs
@@ -195,7 +195,7 @@ pub extern "system" fn event_window_proc(
             IS_SYSTEM_SUSPENDED.store(true, Ordering::Relaxed);
           }
           _ => {}
-        };
+        }
 
         LRESULT(0)
       }

--- a/packages/wm-platform/src/native_window.rs
+++ b/packages/wm-platform/src/native_window.rs
@@ -807,7 +807,7 @@ impl NativeWindow {
           }?;
         }
       }
-    };
+    }
 
     // Whether to hide or show the window.
     self.set_visible(is_visible, hide_method)?;

--- a/packages/wm/src/commands/general/platform_sync.rs
+++ b/packages/wm/src/commands/general/platform_sync.rs
@@ -92,7 +92,7 @@ fn sync_focus(
       info!("Setting focus to window: {window}");
     } else {
       info!("Setting focus to the desktop window.");
-    };
+    }
 
     if let Err(err) = native_window.set_foreground() {
       warn!("Failed to set foreground window: {}", err);
@@ -371,7 +371,7 @@ fn apply_window_effects(
     || window_effects.other_windows.border.enabled
   {
     apply_border_effect(window, effect_config);
-  };
+  }
 
   if window_effects.focused_window.hide_title_bar.enabled
     || window_effects.other_windows.hide_title_bar.enabled

--- a/packages/wm/src/commands/window/move_window_in_direction.rs
+++ b/packages/wm/src/commands/window/move_window_in_direction.rs
@@ -200,7 +200,7 @@ fn move_to_sibling_container(
           .queue_containers_to_redraw(parent.tiling_children());
       }
     }
-  };
+  }
 
   Ok(())
 }
@@ -270,7 +270,7 @@ fn move_to_workspace_in_direction(
       .queue_containers_to_redraw(parent.tiling_children())
       .queue_cursor_jump()
       .queue_workspace_to_reorder(target_workspace);
-  };
+  }
 
   Ok(())
 }

--- a/packages/wm/src/commands/window/move_window_to_workspace.rs
+++ b/packages/wm/src/commands/window/move_window_to_workspace.rs
@@ -137,7 +137,7 @@ pub fn move_window_to_workspace(
           .queue_containers_to_redraw(current_workspace.tiling_children())
           .queue_containers_to_redraw(target_workspace.tiling_children());
       }
-    };
+    }
 
     state
       .pending_sync

--- a/packages/wm/src/events/handle_window_shown.rs
+++ b/packages/wm/src/events/handle_window_shown.rs
@@ -31,7 +31,7 @@ pub fn handle_window_shown(
         manage_window(native_window, None, state, config)?;
       }
     }
-  };
+  }
 
   Ok(())
 }

--- a/packages/wm/src/main.rs
+++ b/packages/wm/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
       if let Err(err) = &res {
         error!("{:?}", err);
         Platform::show_error_dialog("Fatal error", &err.to_string());
-      };
+      }
 
       res
     }

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -288,7 +288,7 @@ impl WindowManager {
                 state,
                 config,
               )?;
-            };
+            }
 
             if let Some(name) = &args.workspace {
               move_window_to_workspace(


### PR DESCRIPTION
<!--
Before submitting a PR, follow this checklist:

1. Give the PR a descriptive title.

  Examples of good titles:
    - fix: fix race condition in message loop
    - docs: update readme with new demo gif
    - feat: add new `general.focus_follows_mouse` config option

  Examples of bad titles:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR description, e.g. closes #123.
3. Propose your changes as a draft PR if your work is still in progress.
-->

This PR adds a settings.json file in the .vscode folder. This will make all VS Code users automatically get the correct indentation settings for this project and use clippy as their rust-analyzer check command, as mentioned in https://github.com/glzr-io/glazewm/blob/main/CONTRIBUTING.md#tips .