### PR TITLE
feat: add `focus_workspace_on_current_monitor` and `swap_monitor` commands

### DIFF
--- a/packages/wm-common/src/app_command.rs
+++ b/packages/wm-common/src/app_command.rs
@@ -160,6 +160,7 @@ pub enum InvokeCommand {
   Close,
   Focus(InvokeFocusCommand),
   FocusWorkspaceOnCurrentMonitor(InvokeFocusWorkspaceOnCurrentMonitorCommand),
+  SwapWorkspace(InvokeSwapWorkspaceCommand),
   Ignore,
   Move(InvokeMoveCommand),
   MoveWorkspace {
@@ -351,6 +352,20 @@ pub struct InvokeFocusWorkspaceOnCurrentMonitorCommand {
 
   #[clap(long)]
   pub recent_workspace: bool,
+}
+
+#[derive(Args, Clone, Debug, PartialEq, Serialize)]
+#[group(required = true, multiple = true, requires_all=["monitor_1", "monitor_2"])]
+#[allow(clippy::struct_excessive_bools)]
+pub struct InvokeSwapWorkspaceCommand {
+  #[clap(long)]
+  pub monitor_1: Option<usize>,
+
+  #[clap(long)]
+  pub monitor_2: Option<usize>,
+
+  #[clap(long)]
+  pub stay_on_monitor: bool
 }
 
 #[derive(Args, Clone, Debug, PartialEq, Serialize)]

--- a/packages/wm-common/src/app_command.rs
+++ b/packages/wm-common/src/app_command.rs
@@ -159,6 +159,7 @@ pub enum InvokeCommand {
   AdjustBorders(InvokeAdjustBordersCommand),
   Close,
   Focus(InvokeFocusCommand),
+  FocusWorkspaceOnCurrentMonitor(InvokeFocusWorkspaceOnCurrentMonitorCommand),
   Ignore,
   Move(InvokeMoveCommand),
   MoveWorkspace {
@@ -312,6 +313,29 @@ pub struct InvokeFocusCommand {
 
   #[clap(long)]
   pub monitor: Option<usize>,
+
+  #[clap(long)]
+  pub next_active_workspace: bool,
+
+  #[clap(long)]
+  pub prev_active_workspace: bool,
+
+  #[clap(long)]
+  pub next_workspace: bool,
+
+  #[clap(long)]
+  pub prev_workspace: bool,
+
+  #[clap(long)]
+  pub recent_workspace: bool,
+}
+
+#[derive(Args, Clone, Debug, PartialEq, Serialize)]
+#[group(required = true, multiple = false)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct InvokeFocusWorkspaceOnCurrentMonitorCommand {
+  #[clap(long)]
+  pub workspace: Option<String>,
 
   #[clap(long)]
   pub next_active_workspace: bool,

--- a/packages/wm/src/commands/workspace/focus_workspace_on_current_monitor.rs
+++ b/packages/wm/src/commands/workspace/focus_workspace_on_current_monitor.rs
@@ -159,6 +159,10 @@ fn move_and_focus(
     .queue_container_to_redraw(focused_workspace.clone())
     .queue_cursor_jump();
 
+  state.emit_event(WmEvent::WorkspaceUpdated {
+    updated_workspace: target_workspace.to_dto()?
+  });
+
   state.recent_workspace_name = Some(target_workspace.config().name);
 
   Ok(())

--- a/packages/wm/src/commands/workspace/focus_workspace_on_current_monitor.rs
+++ b/packages/wm/src/commands/workspace/focus_workspace_on_current_monitor.rs
@@ -1,0 +1,252 @@
+use anyhow::Context;
+use tracing::info;
+use wm_common::WmEvent;
+
+use super::activate_workspace;
+use crate::{
+  commands::{
+    container::{move_container_within_tree, set_focused_descendant},
+    workspace::{deactivate_workspace, sort_workspaces},
+  },
+  models::WorkspaceTarget,
+  traits::{CommonGetters, PositionGetters, WindowGetters},
+  user_config::UserConfig,
+  wm_state::WmState,
+};
+
+/// Focuses a workspace by a given target.
+///
+/// If the target workspace and focused workspace is in the same monitor,
+/// does the same thing as `focus_workspace` function.
+///
+/// If the target workspace is on a different monitor,
+/// it will move target workspace to the focused monitor and focuses it.
+///
+/// If the target workspace is displayed on a different monitor,
+/// it will swap the target workspace and the focused workspace and focuse
+/// the target workspace.
+pub fn focus_workspace_on_current_monitor(
+  target: WorkspaceTarget,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<()> {
+  let focused_workspace = state
+    .focused_container()
+    .and_then(|focused| focused.workspace())
+    .context("No workspace is currently focused.")?;
+
+  let focused_monitor = focused_workspace
+    .monitor()
+    .context("Workspace has no parent monitor.")?;
+
+  let (target_workspace_name, target_workspace) =
+    state.workspace_by_target(&focused_workspace, target, config)?;
+
+  // Retrieve or activate the target workspace by its name.
+  let target_workspace = match target_workspace {
+    Some(_) => anyhow::Ok(target_workspace),
+    _ => match target_workspace_name {
+      Some(name) => {
+        activate_workspace(Some(&name), None, state, config)?;
+
+        Ok(state.workspace_by_name(&name))
+      }
+      _ => Ok(None),
+    },
+  }?;
+
+  if let Some(target_workspace) = target_workspace {
+    info!("Focusing workspace: {target_workspace}");
+    let target_monitor = target_workspace
+      .monitor()
+      .context("Focused workspace has no perent monitor.")?;
+
+    if focused_monitor.id() == target_monitor.id() {
+      // Does the same thing as `focus_workspace`
+      normal_focus(state, &target_workspace, &focused_workspace);
+    } else if target_workspace.is_displayed() {
+      swap_and_focus(state, config, &target_workspace, &focused_workspace)?;
+    } else {
+      move_and_focus(state, config, &target_workspace, &focused_workspace)?;
+    }
+
+    // Get empty workspace to destroy (if one is found). Cannot destroy
+    // empty workspaces if they're the only workspace on the monitor.
+    let workspace_to_destroy =
+      state.workspaces().into_iter().find(|workspace| {
+        !workspace.config().keep_alive
+          && !workspace.has_children()
+          && !workspace.is_displayed()
+      });
+
+    if let Some(workspace) = workspace_to_destroy {
+      deactivate_workspace(workspace, state)?;
+    }
+  }
+  Ok(())
+}
+
+fn normal_focus(
+  state: &mut WmState,
+  target_workspace: &crate::models::Workspace,
+  focused_workspace: &crate::models::Workspace,
+) {
+  info!("Normal focus: {target_workspace}");
+
+  let container_to_focus = target_workspace
+    .descendant_focus_order()
+    .next()
+    .unwrap_or_else(|| target_workspace.clone().into());
+
+  set_focused_descendant(&container_to_focus, None);
+
+
+  state
+    .pending_sync
+    .queue_focus_change()
+    .queue_container_to_redraw(focused_workspace.clone())
+    .queue_container_to_redraw(target_workspace.clone())
+    .queue_cursor_jump();
+
+  state.recent_workspace_name = Some(target_workspace.config().name);
+}
+
+fn move_and_focus(
+  state: &mut WmState,
+  config: &UserConfig,
+  target_workspace: &crate::models::Workspace,
+  focused_workspace: &crate::models::Workspace,
+) -> anyhow::Result<()> {
+  info!("Move focus: {target_workspace}");
+  let focused_monitor = focused_workspace
+    .monitor()
+    .context("Workspace has no monitor")?;
+
+  move_container_within_tree(
+    &target_workspace.clone().as_container(),
+    &focused_monitor.clone().as_container(),
+    focused_monitor.child_count(),
+    state,
+  )?;
+
+  sort_workspaces(&focused_monitor, config)?;
+
+  let windows = target_workspace
+    .descendants()
+    .filter_map(|descendant| descendant.as_window_container().ok());
+
+  for window in windows {
+    window.set_has_pending_dpi_adjustment(true);
+
+    window.set_floating_placement(
+      window
+        .floating_placement()
+        .translate_to_center(&target_workspace.to_rect()?),
+    );
+  }
+
+  let container_to_focus = target_workspace
+    .descendant_focus_order()
+    .next()
+    .unwrap_or_else(|| target_workspace.clone().into());
+
+  set_focused_descendant(&container_to_focus, None);
+
+  state
+    .pending_sync
+    .queue_focus_change()
+    .queue_container_to_redraw(target_workspace.clone())
+    .queue_container_to_redraw(focused_workspace.clone())
+    .queue_cursor_jump();
+
+  state.recent_workspace_name = Some(target_workspace.config().name);
+
+  Ok(())
+}
+
+fn swap_and_focus(
+  state: &mut WmState,
+  config: &UserConfig,
+  target_workspace: &crate::models::Workspace,
+  focused_workspace: &crate::models::Workspace,
+) -> anyhow::Result<()> {
+  info!("Swap focus: swap {target_workspace} and {focused_workspace}");
+  let focused_monitor = focused_workspace
+    .monitor()
+    .context("Workspace has no monitor")?;
+
+  let target_monitor = target_workspace
+    .monitor()
+    .context("Workspace has no monitor")?;
+
+  move_container_within_tree(
+    &target_workspace.clone().as_container(),
+    &focused_monitor.clone().as_container(),
+    focused_monitor.child_count(),
+    state,
+  )?;
+
+  move_container_within_tree(
+    &focused_workspace.clone().as_container(),
+    &target_monitor.clone().as_container(),
+    target_monitor.child_count(),
+    state
+  )?;
+
+  sort_workspaces(&focused_monitor, config)?;
+  sort_workspaces(&target_monitor, config)?;
+
+
+  let windows = target_workspace
+    .descendants()
+    .filter_map(|descendant| descendant.as_window_container().ok());
+
+  for window in windows {
+    window.set_has_pending_dpi_adjustment(true);
+
+    window.set_floating_placement(
+      window
+        .floating_placement()
+        .translate_to_center(&target_workspace.to_rect()?),
+    );
+  }
+
+  let windows = focused_workspace
+    .descendants()
+    .filter_map(|descendant| descendant.as_window_container().ok());
+
+  for window in windows {
+    window.set_has_pending_dpi_adjustment(true);
+
+    window.set_floating_placement(
+      window
+        .floating_placement()
+        .translate_to_center(&focused_workspace.to_rect()?),
+    );
+  }
+
+  let container_to_focus = target_workspace
+    .descendant_focus_order()
+    .next()
+    .unwrap_or_else(|| target_workspace.clone().into());
+
+  set_focused_descendant(&container_to_focus, None);
+
+  state
+    .pending_sync
+    .queue_focus_change()
+    .queue_container_to_redraw(target_workspace.clone())
+    .queue_container_to_redraw(focused_workspace.clone())
+    .queue_cursor_jump();
+
+  state.emit_event(WmEvent::WorkspaceUpdated {
+    updated_workspace: focused_workspace.to_dto()?
+  });
+
+  state.emit_event(WmEvent::WorkspaceUpdated {
+    updated_workspace: target_workspace.to_dto()?
+  });
+
+  state.recent_workspace_name = Some(target_workspace.config().name);
+  Ok(())
+}

--- a/packages/wm/src/commands/workspace/mod.rs
+++ b/packages/wm/src/commands/workspace/mod.rs
@@ -3,9 +3,11 @@ mod deactivate_workspace;
 mod focus_workspace;
 mod move_workspace_in_direction;
 mod sort_workspaces;
+mod focus_workspace_on_current_monitor;
 
 pub use activate_workspace::*;
 pub use deactivate_workspace::*;
 pub use focus_workspace::*;
 pub use move_workspace_in_direction::*;
 pub use sort_workspaces::*;
+pub use focus_workspace_on_current_monitor::*;

--- a/packages/wm/src/commands/workspace/mod.rs
+++ b/packages/wm/src/commands/workspace/mod.rs
@@ -4,6 +4,7 @@ mod focus_workspace;
 mod move_workspace_in_direction;
 mod sort_workspaces;
 mod focus_workspace_on_current_monitor;
+mod swap_workspace;
 
 pub use activate_workspace::*;
 pub use deactivate_workspace::*;
@@ -11,3 +12,4 @@ pub use focus_workspace::*;
 pub use move_workspace_in_direction::*;
 pub use sort_workspaces::*;
 pub use focus_workspace_on_current_monitor::*;
+pub use swap_workspace::*;

--- a/packages/wm/src/commands/workspace/swap_workspace.rs
+++ b/packages/wm/src/commands/workspace/swap_workspace.rs
@@ -1,40 +1,143 @@
 use anyhow::Context;
 use tracing::info;
+use wm_common::WmEvent;
 
-use super::{activate_workspace};
+use super::sort_workspaces;
 use crate::{
-  commands::{
-    container::set_focused_descendant, workspace::deactivate_workspace,
+  commands::container::{
+    move_container_within_tree, set_focused_descendant,
   },
-  traits::CommonGetters,
+  traits::{CommonGetters, PositionGetters, WindowGetters},
   user_config::UserConfig,
   wm_state::WmState,
 };
 
+// This swaps the displayed workspace on monitor 1 and monitor 2.
+//
+// By default, focus does not change. However, if `stay_on_monitor` is enable,
+// the focus with stay on the same monitor.
 pub fn swap_workspace(
-  monitor_a_index: usize,
-  monitor_b_index: usize,
+  monitor_1_index: usize,
+  monitor_2_index: usize,
+  stay_on_monitor: bool,
   state: &mut WmState,
   config: &UserConfig,
 ) -> anyhow::Result<()> {
+  info!("swap_workspace");
+  info!("stay_on_monitor: {stay_on_monitor}");
+
+  let focused_workspace = state
+    .focused_container()
+    .and_then(|focused| focused.workspace())
+    .context("No workspace is currently focused.")?;
+
+  let focused_monitor = focused_workspace
+    .monitor()
+    .context("Workspace has no monitor")?;
+
   let monitors = state.monitors();
-  let monitor_a = monitors
-    .get(monitor_a_index)
-    .with_context(|| format!("Monitor at {monitor_a_index} does not exist."))?;
+  let monitor_1 = monitors.get(monitor_1_index).with_context(|| {
+    format!("Monitor at {monitor_1_index} does not exist.")
+  })?;
 
-  let monitor_b = monitors
-    .get(monitor_b_index)
-    .with_context(|| format!("Monitor at {monitor_b_index} does not exist."))?;
+  let monitor_2 = monitors.get(monitor_2_index).with_context(|| {
+    format!("Monitor at {monitor_2_index} does not exist.")
+  })?;
 
-  let workspace_at_a = monitor_a
+  let workspace_at_1 = monitor_1
     .displayed_workspace()
     .context("No displayed workspace.")?;
 
-  let workspace_at_b = monitor_b
+  let workspace_at_2 = monitor_2
     .displayed_workspace()
     .context("No displayed workspace.")?;
 
+  info!("monitor_1: {monitor_1}");
+  info!("workspace_at_1: {workspace_at_1}");
+  info!("monitor_2: {monitor_2}");
+  info!("workspace_at_2: {workspace_at_2}");
 
+  move_container_within_tree(
+    &workspace_at_1.clone().into(),
+    &monitor_2.clone().into(),
+    monitor_2.child_count(),
+    state,
+  )?;
+
+  move_container_within_tree(
+    &workspace_at_2.clone().into(),
+    &monitor_1.clone().into(),
+    monitor_1.child_count(),
+    state,
+  )?;
+
+  sort_workspaces(monitor_1, config)?;
+  sort_workspaces(monitor_2, config)?;
+
+  let windows = workspace_at_1
+    .descendants()
+    .filter_map(|descendant| descendant.as_window_container().ok());
+
+  for window in windows {
+    window.set_has_pending_dpi_adjustment(true);
+
+    window.set_floating_placement(
+      window
+        .floating_placement()
+        .translate_to_center(&workspace_at_1.to_rect()?),
+    );
+  }
+
+  let windows = workspace_at_2
+    .descendants()
+    .filter_map(|descendant| descendant.as_window_container().ok());
+
+  for window in windows {
+    window.set_has_pending_dpi_adjustment(true);
+
+    window.set_floating_placement(
+      window
+        .floating_placement()
+        .translate_to_center(&workspace_at_2.to_rect()?),
+    );
+  }
+
+  if stay_on_monitor {
+    // Flipped because the workspaces just got swap.
+    let displayed = if focused_monitor.id() == monitor_1.id() {
+      &workspace_at_2
+    } else {
+      &workspace_at_1
+    };
+
+    let container_to_focus = displayed
+      .descendant_focus_order()
+      .next()
+      .unwrap_or_else(|| displayed.clone().into());
+    set_focused_descendant(&container_to_focus, None);
+  } else {
+    let container_to_focus = focused_workspace
+      .descendant_focus_order()
+      .next()
+      .unwrap_or_else(|| focused_workspace.clone().into());
+    set_focused_descendant(&container_to_focus, None);
+  }
+
+  state
+    .pending_sync
+    .queue_focus_change()
+    .queue_container_to_redraw(focused_workspace)
+    .queue_container_to_redraw(workspace_at_1.clone())
+    .queue_container_to_redraw(workspace_at_2.clone())
+    .queue_cursor_jump();
+
+  state.emit_event(WmEvent::WorkspaceUpdated {
+    updated_workspace: workspace_at_1.to_dto()?,
+  });
+
+  state.emit_event(WmEvent::WorkspaceUpdated {
+    updated_workspace: workspace_at_2.to_dto()?,
+  });
 
   Ok(())
 }

--- a/packages/wm/src/commands/workspace/swap_workspace.rs
+++ b/packages/wm/src/commands/workspace/swap_workspace.rs
@@ -1,0 +1,40 @@
+use anyhow::Context;
+use tracing::info;
+
+use super::{activate_workspace};
+use crate::{
+  commands::{
+    container::set_focused_descendant, workspace::deactivate_workspace,
+  },
+  traits::CommonGetters,
+  user_config::UserConfig,
+  wm_state::WmState,
+};
+
+pub fn swap_workspace(
+  monitor_a_index: usize,
+  monitor_b_index: usize,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<()> {
+  let monitors = state.monitors();
+  let monitor_a = monitors
+    .get(monitor_a_index)
+    .with_context(|| format!("Monitor at {monitor_a_index} does not exist."))?;
+
+  let monitor_b = monitors
+    .get(monitor_b_index)
+    .with_context(|| format!("Monitor at {monitor_b_index} does not exist."))?;
+
+  let workspace_at_a = monitor_a
+    .displayed_workspace()
+    .context("No displayed workspace.")?;
+
+  let workspace_at_b = monitor_b
+    .displayed_workspace()
+    .context("No displayed workspace.")?;
+
+
+
+  Ok(())
+}

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -23,7 +23,7 @@ use crate::{
       resize_window, set_window_position, set_window_size,
       update_window_state, WindowPositionTarget,
     },
-    workspace::{focus_workspace, move_workspace_in_direction, focus_workspace_on_current_monitor},
+    workspace::{focus_workspace, move_workspace_in_direction, focus_workspace_on_current_monitor, swap_workspace},
   },
   events::{
     handle_display_settings_changed, handle_mouse_move,
@@ -301,6 +301,12 @@ impl WindowManager {
           focus_workspace_on_current_monitor(WorkspaceTarget::Recent, state, config)?;
         }
 
+        Ok(())
+      }
+      InvokeCommand::SwapWorkspace(args) => {
+        if let (Some(monitor_1_index), Some(monitor_2_index)) = (args.monitor_1, args.monitor_2) {
+          swap_workspace(monitor_1_index, monitor_2_index, args.stay_on_monitor, state, config)?;
+        }
         Ok(())
       }
       InvokeCommand::Ignore => {

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -23,7 +23,7 @@ use crate::{
       resize_window, set_window_position, set_window_size,
       update_window_state, WindowPositionTarget,
     },
-    workspace::{focus_workspace, move_workspace_in_direction},
+    workspace::{focus_workspace, move_workspace_in_direction, focus_workspace_on_current_monitor},
   },
   events::{
     handle_display_settings_changed, handle_mouse_move,
@@ -268,6 +268,37 @@ impl WindowManager {
 
         if args.recent_workspace {
           focus_workspace(WorkspaceTarget::Recent, state, config)?;
+        }
+
+        Ok(())
+      }
+      InvokeCommand::FocusWorkspaceOnCurrentMonitor(args) => {
+        if let Some(name) = &args.workspace {
+          focus_workspace_on_current_monitor(
+            WorkspaceTarget::Name(name.to_string()),
+            state,
+            config,
+          )?;
+        }
+
+        if args.next_active_workspace {
+          focus_workspace_on_current_monitor(WorkspaceTarget::NextActive, state, config)?;
+        }
+
+        if args.prev_active_workspace {
+          focus_workspace_on_current_monitor(WorkspaceTarget::PreviousActive, state, config)?;
+        }
+
+        if args.next_workspace {
+          focus_workspace_on_current_monitor(WorkspaceTarget::Next, state, config)?;
+        }
+
+        if args.prev_workspace {
+          focus_workspace_on_current_monitor(WorkspaceTarget::Previous, state, config)?;
+        }
+
+        if args.recent_workspace {
+          focus_workspace_on_current_monitor(WorkspaceTarget::Recent, state, config)?;
         }
 
         Ok(())


### PR DESCRIPTION
Added two new commands

## `focus_workspace_on_current_monitor`
This is a slight addition to `focus_workspace` command

This focuses a workspace by a given target.
- If the target workspace and focused workspace is in the same monitor, it does the same thing as `focus_workspace` function.
- If the target workspace is on a different monitor, it will move target workspace to the focused monitor and focuses it.
- If the target workspace is displayed on a different monitor, it will swap the target workspace and the focused workspace. After that, focus the target workspace.

## `swap_monitor`
Swaps the active workspace on `monitor a` and `monitor b`.

- By default, focus stay the same. However, if `stay_on_monitor` is enable, the focus with stay on the same monitor.