### PR TITLE
feat: add `--next-active-workspace-on-monitor` and `--prev-active-workspace-on-monitor` to `focus` and `move` commands

### DIFF
--- a/packages/wm-common/src/app_command.rs
+++ b/packages/wm-common/src/app_command.rs
@@ -363,6 +363,12 @@ pub struct InvokeMoveCommand {
   pub prev_workspace: bool,
 
   #[clap(long)]
+  pub next_active_workspace_on_monitor: bool,
+
+  #[clap(long)]
+  pub prev_active_workspace_on_monitor: bool,
+
+  #[clap(long)]
   pub recent_workspace: bool,
 }
 

--- a/packages/wm-common/src/app_command.rs
+++ b/packages/wm-common/src/app_command.rs
@@ -329,6 +329,12 @@ pub struct InvokeFocusCommand {
   pub prev_workspace: bool,
 
   #[clap(long)]
+  pub next_active_workspace_in_monitor: bool,
+
+  #[clap(long)]
+  pub prev_active_workspace_in_monitor: bool,
+
+  #[clap(long)]
   pub recent_workspace: bool,
 }
 

--- a/packages/wm-common/src/app_command.rs
+++ b/packages/wm-common/src/app_command.rs
@@ -329,10 +329,10 @@ pub struct InvokeFocusCommand {
   pub prev_workspace: bool,
 
   #[clap(long)]
-  pub next_active_workspace_in_monitor: bool,
+  pub next_active_workspace_on_monitor: bool,
 
   #[clap(long)]
-  pub prev_active_workspace_in_monitor: bool,
+  pub prev_active_workspace_on_monitor: bool,
 
   #[clap(long)]
   pub recent_workspace: bool,

--- a/packages/wm/src/models/workspace_target.rs
+++ b/packages/wm/src/models/workspace_target.rs
@@ -5,6 +5,8 @@ pub enum WorkspaceTarget {
   Recent,
   NextActive,
   PreviousActive,
+  NextActiveInMonitor,
+  PreviousActiveInMonitor,
   Next,
   Previous,
   #[allow(dead_code)]

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -275,6 +275,22 @@ impl WindowManager {
           focus_workspace(WorkspaceTarget::Recent, state, config)?;
         }
 
+        if args.next_active_workspace_in_monitor {
+          focus_workspace(
+            WorkspaceTarget::NextActiveInMonitor,
+            state,
+            config,
+          )?;
+        }
+
+        if args.prev_active_workspace_in_monitor {
+          focus_workspace(
+            WorkspaceTarget::PreviousActiveInMonitor,
+            state,
+            config,
+          )?;
+        }
+
         Ok(())
       }
       InvokeCommand::Ignore => {

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -358,15 +358,33 @@ impl WindowManager {
 
             if args.recent_workspace {
               move_window_to_workspace(
-                window,
+                window.clone(),
                 WorkspaceTarget::Recent,
                 state,
                 config,
               )?;
             }
 
+            if args.next_active_workspace_on_monitor {
+              move_window_to_workspace(
+                window.clone(),
+                WorkspaceTarget::NextActiveInMonitor,
+                state,
+                config,
+              )?;
+            }
+
+            if args.prev_active_workspace_on_monitor {
+              move_window_to_workspace(
+                window,
+                WorkspaceTarget::PreviousActiveInMonitor,
+                state,
+                config,
+              )?;
+            }
             Ok(())
           }
+
           _ => Ok(()),
         }
       }

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -275,7 +275,7 @@ impl WindowManager {
           focus_workspace(WorkspaceTarget::Recent, state, config)?;
         }
 
-        if args.next_active_workspace_in_monitor {
+        if args.next_active_workspace_on_monitor {
           focus_workspace(
             WorkspaceTarget::NextActiveInMonitor,
             state,
@@ -283,7 +283,7 @@ impl WindowManager {
           )?;
         }
 
-        if args.prev_active_workspace_in_monitor {
+        if args.prev_active_workspace_on_monitor {
           focus_workspace(
             WorkspaceTarget::PreviousActiveInMonitor,
             state,

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -332,6 +332,54 @@ impl WmState {
           prev_active_workspace.cloned(),
         )
       }
+      WorkspaceTarget::NextActiveInMonitor => {
+        let monitor = origin_workspace
+          .monitor()
+          .context("No monitor in workspace")?;
+
+        let mut workspace_in_monitor = monitor.workspaces();
+        config.sort_workspaces(&mut workspace_in_monitor);
+
+        let origin_index = workspace_in_monitor
+          .iter()
+          .position(|workspace| workspace.id() == origin_workspace.id())
+          .context("Failed to get index of give workspace")?;
+
+        let next_active_workspace_in_monitor = workspace_in_monitor
+          .get(origin_index + 1)
+          .or_else(|| workspace_in_monitor.first());
+
+        (
+          next_active_workspace_in_monitor
+            .map(|workspace| workspace.config().name),
+          next_active_workspace_in_monitor.cloned(),
+        )
+      }
+      WorkspaceTarget::PreviousActiveInMonitor => {
+        let monitor = origin_workspace
+          .monitor()
+          .context("No monitor in workspace")?;
+
+        let mut workspace_in_monitor = monitor.workspaces();
+        config.sort_workspaces(&mut workspace_in_monitor);
+
+        let origin_index = workspace_in_monitor
+          .iter()
+          .position(|workspace| workspace.id() == origin_workspace.id())
+          .context("Failed to get index of give workspace")?;
+
+        let prev_active_workspace_in_monitor = workspace_in_monitor.get(
+          origin_index
+            .checked_sub(1)
+            .unwrap_or(workspace_in_monitor.len() - 1),
+        );
+
+        (
+          prev_active_workspace_in_monitor
+            .map(|workspace| workspace.config().name),
+          prev_active_workspace_in_monitor.cloned(),
+        )
+      }
       WorkspaceTarget::Next => {
         let workspaces = &config.value.workspaces;
         let origin_name = origin_workspace.config().name.clone();


### PR DESCRIPTION
close #938 
Also added `NextActiveInMonitor` and `PreviousActiveInMonitor` to `WorkspaceTarget` and their respective implementations.