### PR TITLE
feat: activate `keep_alive` workspaces on their bound monitor

### DIFF
--- a/packages/wm/src/commands/monitor/add_monitor.rs
+++ b/packages/wm/src/commands/monitor/add_monitor.rs
@@ -36,6 +36,7 @@ pub fn add_monitor(
   // Active all keep_alive workspaces for this monitor
   config.keep_alive_workspace_configs().iter().for_each(
     |workspace_config| {
+      #[allow(clippy::cast_possible_truncation)]
       if workspace_config.bind_to_monitor == Some(monitor.index() as u32) {
         activate_workspace(
           Some(&workspace_config.name),

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -281,6 +281,15 @@ impl UserConfig {
       .collect()
   }
 
+  pub fn keep_alive_workspace_configs(&self) -> Vec<&WorkspaceConfig> {
+    self
+      .value
+      .workspaces
+      .iter()
+      .filter(|config| config.keep_alive)
+      .collect()
+  }
+
   pub fn workspace_config_for_monitor(
     &self,
     monitor: &Monitor,


### PR DESCRIPTION
Initializes keep_alive workspaces.  Previous workaround was focusing each of the workspaces manually or using startup commands like this:
```
startup_commands: 
    - shell-exec zebar
    - move --workspace 2
    - move --workspace 3
    - move --workspace 4
    - move --workspace 5
    - move --workspace 6
    - move --workspace 7
    - move --workspace 8
    - move --workspace 1