### PR TITLE
docs: replace GLA-ALT with maintained fork in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Create a shortcut for the executable by right-clicking on the GlazeWM executable
 
 You can create custom layouts by changing the tiling direction with `alt+v`. This changes where the next window is placed _in relation to the current window_. If the current window's direction is horizontal, the new window will be placed to the right of it. If it is vertical, it will be placed below it. This also applies when moving windows; the tiling direction of the stationary window will affect where the moved window will be placed.
 
-Community-made scripts like [ParasiteDelta/GlaAlt](https://github.com/ParasiteDelta/GlaAlt) and [burgr033/GlazeWM-autotiling-python](https://github.com/burgr033/GlazeWM-autotiling-python) can be used to automatically change the tiling direction. Native support for automatic layouts isn't _currently_ supported.
+Community-made scripts like [Dutch-Raptor/GAT-GWM](https://github.com/Dutch-Raptor/GAT-GWM) and [burgr033/GlazeWM-autotiling-python](https://github.com/burgr033/GlazeWM-autotiling-python) can be used to automatically change the tiling direction. Native support for automatic layouts isn't _currently_ supported.
 
 **Q: How do I create a rule for `<insert application>`?**
 


### PR DESCRIPTION
The old [GLA-ALT](https://github.com/ParasiteDelta/GAT-GWM) repo for auto-tiling was archived then made private. This fork seems to have the [last commit](https://github.com/Dutch-Raptor/GAT-GWM/commit/b76822bd0da1fb7ab685beb5663c8cded535ab6b) from the old repo ([archived version](https://web.archive.org/web/20241112231905/https://github.com/ParasiteDelta/GAT-GWM)) and has some additional improvements made as well. Note that the repo was renamed to GAT-GWM by the original dev as can be seen in the archived link above.