### PR TITLE
fix: broadcast focus change events when focus is manually changed

### DIFF
--- a/packages/wm/src/events/handle_window_focused.rs
+++ b/packages/wm/src/events/handle_window_focused.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use tracing::info;
-use wm_common::{DisplayState, WindowRuleEvent};
+use wm_common::{DisplayState, WindowRuleEvent, WmEvent};
 use wm_platform::{NativeWindow, Platform};
 
 use crate::{
@@ -84,14 +84,21 @@ pub fn handle_window_focused(
     // Update the WM's focus state.
     set_focused_descendant(&window.clone().into(), None);
 
-    // Queue focus change to ensure focus_changed event is emitted
-    state.pending_sync.queue_focus_change();
-
     // Run window rules for focus events.
-    run_window_rules(window, &WindowRuleEvent::Focus, state, config)?;
+    run_window_rules(
+      window.clone(),
+      &WindowRuleEvent::Focus,
+      state,
+      config,
+    )?;
 
     state.is_focus_synced = true;
     state.pending_sync.queue_workspace_to_reorder(workspace);
+
+    // Broadcast the focus change event.
+    state.emit_event(WmEvent::FocusChanged {
+      focused_container: window.to_dto()?,
+    });
   }
 
   Ok(())

--- a/packages/wm/src/events/handle_window_focused.rs
+++ b/packages/wm/src/events/handle_window_focused.rs
@@ -84,6 +84,9 @@ pub fn handle_window_focused(
     // Update the WM's focus state.
     set_focused_descendant(&window.clone().into(), None);
 
+    // Queue focus change to ensure focus_changed event is emitted
+    state.pending_sync.queue_focus_change();
+
     // Run window rules for focus events.
     run_window_rules(window, &WindowRuleEvent::Focus, state, config)?;
 


### PR DESCRIPTION
<!--
Before submitting a PR, follow this checklist:

1. Give the PR a descriptive title.

  Examples of good titles:
    - fix: fix race condition in message loop
    - docs: update readme with new demo gif
    - feat: add new `general.focus_follows_mouse` config option

  Examples of bad titles:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR description, e.g. closes #123.
3. Propose your changes as a draft PR if your work is still in progress.
-->

Before: 

https://github.com/user-attachments/assets/601242bc-0047-442a-9796-570d8357b109


After:

https://github.com/user-attachments/assets/a9068f34-89a9-4ba6-9bbe-7dbc867a5d84

