### PR TITLE
refactor: Remove `EnumAsInner`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,18 +408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.103",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,7 +2288,6 @@ dependencies = [
  "ambassador",
  "anyhow",
  "clap",
- "enum-as-inner",
  "futures-util",
  "home",
  "serde",

--- a/packages/wm/Cargo.toml
+++ b/packages/wm/Cargo.toml
@@ -21,7 +21,6 @@ tauri-winres = { workspace = true }
 anyhow = { workspace = true }
 ambassador = "0.4"
 clap = { workspace = true }
-enum-as-inner = "0.6"
 futures-util = { workspace = true }
 home = { workspace = true }
 serde = { workspace = true }

--- a/packages/wm/src/commands/container/detach_container.rs
+++ b/packages/wm/src/commands/container/detach_container.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 
 use super::flatten_split_container;
 use crate::{
-  models::Container,
+  models::{Container, SplitContainer},
   traits::{CommonGetters, TilingSizeGetters, MIN_TILING_SIZE},
 };
 
@@ -16,7 +16,7 @@ pub fn detach_container(child_to_remove: Container) -> anyhow::Result<()> {
   // the child.
   if let Some(split_parent) = child_to_remove
     .parent()
-    .and_then(|parent| parent.as_split().cloned())
+    .and_then(|parent| SplitContainer::try_from(parent.clone()).ok())
   {
     if split_parent.child_count() == 1 {
       flatten_split_container(split_parent)?;

--- a/packages/wm/src/commands/container/focus_in_direction.rs
+++ b/packages/wm/src/commands/container/focus_in_direction.rs
@@ -3,7 +3,7 @@ use wm_common::{Direction, TilingDirection, WindowState};
 
 use super::set_focused_descendant;
 use crate::{
-  models::{Container, TilingContainer},
+  models::{Container, NonTilingWindow, TilingContainer},
   traits::{CommonGetters, TilingDirectionGetters, WindowGetters},
   wm_state::WmState,
 };
@@ -53,7 +53,7 @@ fn floating_focus_target(
   direction: &Direction,
 ) -> Option<Container> {
   let is_floating = |sibling: &Container| {
-    sibling.as_non_tiling_window().is_some_and(|window| {
+    <&NonTilingWindow>::try_from(sibling).is_ok_and(|window| {
       matches!(window.state(), WindowState::Floating(_))
     })
   };
@@ -87,7 +87,7 @@ fn tiling_focus_target(
 
   // Traverse upwards from the focused container. Stop searching when a
   // workspace is encountered.
-  while !origin_or_ancestor.is_workspace() {
+  while !matches!(origin_or_ancestor, Container::Workspace(_)) {
     let parent = origin_or_ancestor
       .parent()
       .and_then(|parent| parent.as_direction_container().ok())

--- a/packages/wm/src/commands/window/manage_window.rs
+++ b/packages/wm/src/commands/window/manage_window.rs
@@ -258,7 +258,7 @@ fn insertion_target(
       Container::TilingWindow(_) => Some(focused_container),
       _ => focused_workspace
         .descendant_focus_order()
-        .find(Container::is_tiling_window),
+        .find(|c| matches!(c, Container::TilingWindow(_))),
     };
 
     if let Some(sibling) = sibling {

--- a/packages/wm/src/commands/window/move_window_in_direction.rs
+++ b/packages/wm/src/commands/window/move_window_in_direction.rs
@@ -56,7 +56,7 @@ fn move_tiling_window(
   // Flatten the parent split container if it only contains the window.
   if let Some(split_parent) = window_to_move
     .parent()
-    .and_then(|parent| parent.as_split().cloned())
+    .and_then(|parent| SplitContainer::try_from(parent).ok())
   {
     if split_parent.child_count() == 1 {
       flatten_split_container(split_parent)?;
@@ -87,7 +87,7 @@ fn move_tiling_window(
   // Attempt to move the window to workspace in given direction.
   if (has_matching_tiling_direction
     || window_to_move.tiling_siblings().count() == 0)
-    && parent.is_workspace()
+    && matches!(parent, DirectionContainer::Workspace(_))
   {
     return move_to_workspace_in_direction(
       &window_to_move.into(),

--- a/packages/wm/src/commands/window/move_window_to_workspace.rs
+++ b/packages/wm/src/commands/window/move_window_to_workspace.rs
@@ -88,8 +88,8 @@ pub fn move_window_to_workspace(
       .find(|descendant| descendant.state() == WindowState::Tiling);
 
     // Insert the window into the target workspace.
-    match (window.is_tiling_window(), insertion_sibling.is_some()) {
-      (true, true) => {
+    match (&window, insertion_sibling.is_some()) {
+      (WindowContainer::TilingWindow(_), true) => {
         if let Some(insertion_sibling) = insertion_sibling {
           move_container_within_tree(
             &window.clone().into(),

--- a/packages/wm/src/events/handle_window_location_changed.rs
+++ b/packages/wm/src/events/handle_window_location_changed.rs
@@ -11,7 +11,7 @@ use crate::{
     container::{flatten_split_container, move_container_within_tree},
     window::update_window_state,
   },
-  models::{TilingWindow, WindowContainer},
+  models::{SplitContainer, TilingWindow, WindowContainer},
   traits::{CommonGetters, PositionGetters, WindowGetters},
   user_config::UserConfig,
   wm_state::WmState,
@@ -56,7 +56,7 @@ pub fn handle_window_location_changed(
       .context("Failed to get workspace of nearest monitor.")?;
 
     // TODO: Include this as part of the `match` statement below.
-    if let Some(tiling_window) = window.as_tiling_window() {
+    if let Ok(tiling_window) = <&TilingWindow>::try_from(&window) {
       update_drag_state(
         tiling_window,
         &frame_position,
@@ -220,7 +220,7 @@ fn update_drag_state(
         .dequeue_container_from_redraw(window.clone());
 
       // Flatten the parent split container if it only contains the window.
-      if let Some(split_parent) = parent.as_split() {
+      if let Ok(split_parent) = SplitContainer::try_from(parent) {
         if split_parent.child_count() == 1 {
           flatten_split_container(split_parent.clone())?;
 

--- a/packages/wm/src/events/handle_window_moved_or_resized_end.rs
+++ b/packages/wm/src/events/handle_window_moved_or_resized_end.rs
@@ -12,8 +12,8 @@ use crate::{
     window::{resize_window, update_window_state},
   },
   models::{
-    DirectionContainer, NonTilingWindow, SplitContainer, TilingContainer,
-    WindowContainer,
+    Container, DirectionContainer, NonTilingWindow, SplitContainer,
+    TilingContainer, WindowContainer,
   },
   traits::{
     CommonGetters, PositionGetters, TilingDirectionGetters, WindowGetters,
@@ -65,7 +65,9 @@ pub fn handle_window_moved_or_resized_end(
 
         // Snap window to its original position if it's the only window in
         // the workspace.
-        if parent.is_workspace() && window.tiling_siblings().count() == 0 {
+        if matches!(parent, Container::Workspace(_))
+          && window.tiling_siblings().count() == 0
+        {
           state.pending_sync.queue_container_to_redraw(window.clone());
           return Ok(());
         }
@@ -157,17 +159,18 @@ fn drop_as_tiling_window(
     config,
   )?;
 
-  let should_split = nearest_container.is_tiling_window()
-    && match tiling_direction {
-      TilingDirection::Horizontal => {
-        drop_position == DropPosition::Top
-          || drop_position == DropPosition::Bottom
-      }
-      TilingDirection::Vertical => {
-        drop_position == DropPosition::Left
-          || drop_position == DropPosition::Right
-      }
-    };
+  let should_split =
+    matches!(nearest_container, TilingContainer::TilingWindow(_))
+      && match tiling_direction {
+        TilingDirection::Horizontal => {
+          drop_position == DropPosition::Top
+            || drop_position == DropPosition::Bottom
+        }
+        TilingDirection::Vertical => {
+          drop_position == DropPosition::Left
+            || drop_position == DropPosition::Right
+        }
+      };
 
   if should_split {
     let split_container = SplitContainer::new(

--- a/packages/wm/src/events/handle_window_moved_or_resized_start.rs
+++ b/packages/wm/src/events/handle_window_moved_or_resized_start.rs
@@ -1,7 +1,9 @@
 use wm_common::ActiveDrag;
 use wm_platform::NativeWindow;
 
-use crate::{traits::WindowGetters, wm_state::WmState};
+use crate::{
+  models::WindowContainer, traits::WindowGetters, wm_state::WmState,
+};
 
 /// Handles the event for when a window is started being moved or resized
 /// by the user (e.g. via the window's drag handles).
@@ -19,7 +21,10 @@ pub fn handle_window_moved_or_resized_start(
   if let Some(found_window) = found_window {
     found_window.set_active_drag(Some(ActiveDrag {
       operation: None,
-      is_from_tiling: found_window.is_tiling_window(),
+      is_from_tiling: matches!(
+        found_window,
+        WindowContainer::TilingWindow(_)
+      ),
     }));
   }
 }

--- a/packages/wm/src/models/container.rs
+++ b/packages/wm/src/models/container.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use ambassador::Delegate;
-use enum_as_inner::EnumAsInner;
 use uuid::Uuid;
 use wm_common::{
   ActiveDrag, ContainerDto, Direction, DisplayState, GapsConfig, Rect,
@@ -56,18 +55,13 @@ use crate::{
 /// }
 /// ```
 #[derive(
-  Clone,
-  Debug,
-  EnumAsInner,
-  wm_macros::EnumFromInner,
-  Delegate,
-  wm_macros::SubEnum,
+  Clone, Debug, wm_macros::EnumFromInner, Delegate, wm_macros::SubEnum,
 )]
 #[delegate(CommonGetters)]
 #[delegate(PositionGetters)]
 #[subenum(defaults, {
   /// Subenum of [Container]
-  #[derive(Clone, Debug, EnumAsInner, Delegate, wm_macros::EnumFromInner)]
+  #[derive(Clone, Debug, Delegate, wm_macros::EnumFromInner)]
   #[delegate(CommonGetters)]
   #[delegate(PositionGetters)]
 })]

--- a/packages/wm/src/models/monitor.rs
+++ b/packages/wm/src/models/monitor.rs
@@ -54,14 +54,14 @@ impl Monitor {
     self
       .child_focus_order()
       .next()
-      .and_then(|child| child.as_workspace().cloned())
+      .and_then(|child| Workspace::try_from(child).ok())
   }
 
   pub fn workspaces(&self) -> Vec<Workspace> {
     self
       .children()
       .into_iter()
-      .filter_map(|container| container.as_workspace().cloned())
+      .filter_map(|container| Workspace::try_from(container).ok())
       .collect()
   }
 

--- a/packages/wm/src/models/root_container.rs
+++ b/packages/wm/src/models/root_container.rs
@@ -50,7 +50,7 @@ impl RootContainer {
     self
       .children()
       .into_iter()
-      .filter_map(|container| container.as_monitor().cloned())
+      .filter_map(|container| Monitor::try_from(container).ok())
       .collect()
   }
 

--- a/packages/wm/src/traits/common_getters.rs
+++ b/packages/wm/src/traits/common_getters.rs
@@ -226,7 +226,7 @@ pub trait CommonGetters {
   fn workspace(&self) -> Option<Workspace> {
     self
       .self_and_ancestors()
-      .find_map(|container| container.as_workspace().cloned())
+      .find_map(|container| Workspace::try_from(container).ok())
   }
 
   /// Monitor that this container belongs to.
@@ -235,7 +235,7 @@ pub trait CommonGetters {
   fn monitor(&self) -> Option<Monitor> {
     self
       .self_and_ancestors()
-      .find_map(|container| container.as_monitor().cloned())
+      .find_map(|container| Monitor::try_from(container).ok())
   }
 
   /// Nearest direction container (i.e. split container or workspace) that


### PR DESCRIPTION
Follow up for the `SubEnum` macro, removing `EnumAsInner` dependancy as the same functionality can be achieved using the methods generated by `SubEnum` and `EnumFromInner`.