### PR TITLE
fix: avoid recentering manually placed floating windows when unplugging usbs

### DIFF
--- a/packages/wm/src/commands/window/set_window_position.rs
+++ b/packages/wm/src/commands/window/set_window_position.rs
@@ -35,6 +35,10 @@ pub fn set_window_position(
     };
 
     window.set_floating_placement(new_placement);
+
+    let is_centered = matches!(target, WindowPositionTarget::Centered);
+    window.set_has_custom_floating_placement(!is_centered);
+
     state.pending_sync.queue_container_to_redraw(window);
   }
 


### PR DESCRIPTION
Currently in GlazeWM, it assumes any change reported by the OS is a display setting change, but sometimes this is just an unrelated event, such a usb being unplugged/replugged.

The problem is that if the user has a floating window that has been positioned (either manually moved or moved via the position command), this window will be automatically recentered because the positioning might have changed.

This PR checks if the window was placed by the user and if it still overlaps with the workspace after the change before forcefully recentering.