### PR TITLE
fix: Update config to ignore new PT Command Palette

### DIFF
--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -143,6 +143,8 @@ window_rules:
       # Ignore rules for various 3rd-party apps.
       - window_process: { equals: 'PowerToys' }
         window_class: { regex: 'HwndWrapper\[PowerToys\.PowerAccent.*?\]' }
+      - window_title: { equals: 'Command Palette' }
+        window_class: { equals: 'WinUIDesktopWin32WindowClass' }
       - window_process: { equals: 'PowerToys' }
         window_title: { regex: '.*? - Peek' }
       - window_process: { equals: 'Lively' }


### PR DESCRIPTION
Microsoft recently added a new Command Palette/Runner to PowerToys and it's getting tiled ( #1138 ).
After fighting with WinSpy++ I think I found the correct title + class combination to ignore it. Works for me, but I'm still new to both the project and "Windows windows inspections". If I messed up something else, or maybe there's a more optimal way to do this change, lmk (or take inspiration and close this commit - I'm ok with that).

Thanks for software and have a great day!