### PR TITLE
feat: add new `general.switch_workspace_on_focus` config option

### DIFF
--- a/packages/wm-common/src/parsed_config.rs
+++ b/packages/wm-common/src/parsed_config.rs
@@ -74,6 +74,10 @@ pub struct GeneralConfig {
   /// Whether to automatically focus windows underneath the cursor.
   pub focus_follows_cursor: bool,
 
+  /// Whether to allow windows to steal focus and change workspaces automatically.
+  /// When set to false, workspace switches will only occur when explicitly triggered.
+  pub steal_focus: bool,
+
   /// Whether to switch back and forth between the previously focused
   /// workspace when focusing the current workspace.
   pub toggle_workspace_on_refocus: bool,
@@ -100,6 +104,7 @@ impl Default for GeneralConfig {
     GeneralConfig {
       cursor_jump: CursorJumpConfig::default(),
       focus_follows_cursor: false,
+      steal_focus: true,
       toggle_workspace_on_refocus: true,
       startup_commands: vec![],
       shutdown_commands: vec![],

--- a/packages/wm-common/src/parsed_config.rs
+++ b/packages/wm-common/src/parsed_config.rs
@@ -74,9 +74,9 @@ pub struct GeneralConfig {
   /// Whether to automatically focus windows underneath the cursor.
   pub focus_follows_cursor: bool,
 
-  /// Whether to allow windows to steal focus and change workspaces automatically.
+  /// Whether to change workspaces when an off-screen window is focused.
   /// When set to false, workspace switches will only occur when explicitly triggered.
-  pub steal_focus: bool,
+  pub switch_workspace_on_focus: bool,
 
   /// Whether to switch back and forth between the previously focused
   /// workspace when focusing the current workspace.
@@ -104,7 +104,7 @@ impl Default for GeneralConfig {
     GeneralConfig {
       cursor_jump: CursorJumpConfig::default(),
       focus_follows_cursor: false,
-      steal_focus: true,
+      switch_workspace_on_focus: true,
       toggle_workspace_on_refocus: true,
       startup_commands: vec![],
       shutdown_commands: vec![],

--- a/packages/wm/src/events/handle_window_focused.rs
+++ b/packages/wm/src/events/handle_window_focused.rs
@@ -68,16 +68,15 @@ pub fn handle_window_focused(
 
     info!("Window manually focused: {window}");
 
-    // Check if focus stealing is disabled - if so, block ALL automatic focus changes
-    if !config.value.general.steal_focus {
-      info!("Window focus change blocked by steal_focus setting: {window}");
-      return Ok(());
-    }
-
     // Handle focus events from windows on hidden workspaces. For example,
     // if Discord is forcefully shown by the OS when it's on a hidden
     // workspace, switch focus to Discord's workspace.
     if window.display_state() == DisplayState::Hidden {
+      // Check the config to see if workspace switching is allowed for hidden windows.
+      if !config.value.general.switch_workspace_on_focus {
+        info!("Workspace switch blocked by switch_workspace_on_focus setting for off-screen window: {window}");
+        return Ok(());
+      }
       info!("Focusing off-screen window: {window}");
 
       focus_workspace(

--- a/packages/wm/src/events/handle_window_focused.rs
+++ b/packages/wm/src/events/handle_window_focused.rs
@@ -68,6 +68,12 @@ pub fn handle_window_focused(
 
     info!("Window manually focused: {window}");
 
+    // Check if focus stealing is disabled - if so, block ALL automatic focus changes
+    if !config.value.general.steal_focus {
+      info!("Window focus change blocked by steal_focus setting: {window}");
+      return Ok(());
+    }
+
     // Handle focus events from windows on hidden workspaces. For example,
     // if Discord is forcefully shown by the OS when it's on a hidden
     // workspace, switch focus to Discord's workspace.

--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -14,6 +14,10 @@ general:
   # Whether to automatically focus windows underneath the cursor.
   focus_follows_cursor: false
 
+  # Whether to allow windows to steal focus and change workspaces automatically.
+  # When set to false, workspace switches will only occur when explicitly triggered.
+  steal_focus: true
+
   # Whether to switch back and forth between the previously focused
   # workspace when focusing the current workspace.
   toggle_workspace_on_refocus: false

--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -14,9 +14,9 @@ general:
   # Whether to automatically focus windows underneath the cursor.
   focus_follows_cursor: false
 
-  # Whether to allow windows to steal focus and change workspaces automatically.
+  # Whether to change workspaces when an off-screen window is focused.
   # When set to false, workspace switches will only occur when explicitly triggered.
-  steal_focus: true
+  switch_workspace_on_focus: true
 
   # Whether to switch back and forth between the previously focused
   # workspace when focusing the current workspace.


### PR DESCRIPTION
closes #783 

Before:
- I'm working on my IDE (workspace 3) 
- Same project folder is open in [_Files_](https://github.com/files-community/Files) (workspace 5)
- Each time I edit a file, _Files_ will steal focus and workspace is switched

After:
- Focus stealing from a hidden window is ignored, and workspace is only switched when explicit

Example steps to reproduce:
1. Open Downloads folder in [_Files_](https://github.com/files-community/Files) (Windows explorer doesn't do this)
2. Switch to another workspace
3. Open a browser, and download something
4. Workspace is switched to one containing _Files_

Disclaimer: I don't write Rust, so some AI help was used, with thorough review