### PR TITLE
feat: added workspace property `cycle_ignore`

### DIFF
--- a/packages/wm-common/src/parsed_config.rs
+++ b/packages/wm-common/src/parsed_config.rs
@@ -378,6 +378,9 @@ pub struct WorkspaceConfig {
 
   #[serde(default = "default_bool::<false>")]
   pub keep_alive: bool,
+
+  #[serde(default = "default_bool::<false>")]
+  pub cycle_ignore: bool,
 }
 
 /// Helper function for setting a default value for a boolean field.

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -26,6 +26,9 @@ pub struct UserConfig {
   /// Unparsed user config string.
   pub value_str: String,
 
+  /// Workspaces that don't have `cycle_ignore` set to `true`.
+  pub filtered_workspaces: Vec<WorkspaceConfig>,
+
   /// Hashmap of window rule event types (e.g. `WindowRuleEvent::Manage`)
   /// and the corresponding window rules of that type.
   window_rules_by_event: HashMap<WindowRuleEvent, Vec<WindowRuleConfig>>,
@@ -49,11 +52,19 @@ impl UserConfig {
 
     let window_rules_by_event = Self::window_rules_by_event(&config_value);
 
+    let filtered_workspaces = config_value
+      .workspaces
+      .iter()
+      .filter(|w| !w.cycle_ignore)
+      .cloned()
+      .collect();
+
     Ok(Self {
       path: config_path,
       value: config_value,
       value_str: config_str,
       window_rules_by_event,
+      filtered_workspaces,
     })
   }
 
@@ -98,6 +109,12 @@ impl UserConfig {
 
     self.window_rules_by_event =
       Self::window_rules_by_event(&config_value);
+    self.filtered_workspaces = config_value
+      .workspaces
+      .iter()
+      .filter(|w| !w.cycle_ignore)
+      .cloned()
+      .collect();
     self.value = config_value;
     self.value_str = config_str;
 

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -304,15 +304,19 @@ impl WmState {
           .and_then(|name| self.workspace_by_name(name)),
       ),
       WorkspaceTarget::NextActive => {
-        let active_workspaces = self.sorted_workspaces(config);
+        let mut active_workspaces = self.sorted_workspaces(config);
+        active_workspaces.retain(|w| !w.config().cycle_ignore);
+
         let origin_index = active_workspaces
           .iter()
-          .position(|workspace| workspace.id() == origin_workspace.id())
-          .context("Failed to get index of given workspace.")?;
+          .position(|workspace| workspace.id() == origin_workspace.id());
 
-        let next_active_workspace = active_workspaces
-          .get(origin_index + 1)
-          .or_else(|| active_workspaces.first());
+        let next_active_workspace = match origin_index {
+          Some(idx) => active_workspaces
+            .get(idx + 1)
+            .or_else(|| active_workspaces.first()),
+          None => active_workspaces.first(),
+        };
 
         (
           next_active_workspace.map(|workspace| workspace.config().name),
@@ -320,17 +324,19 @@ impl WmState {
         )
       }
       WorkspaceTarget::PreviousActive => {
-        let active_workspaces = self.sorted_workspaces(config);
+        let mut active_workspaces = self.sorted_workspaces(config);
+        active_workspaces.retain(|w| !w.config().cycle_ignore);
+
         let origin_index = active_workspaces
           .iter()
-          .position(|workspace| workspace.id() == origin_workspace.id())
-          .context("Failed to get index of given workspace.")?;
+          .position(|workspace| workspace.id() == origin_workspace.id());
 
-        let prev_active_workspace = active_workspaces.get(
-          origin_index
-            .checked_sub(1)
-            .unwrap_or(active_workspaces.len() - 1),
-        );
+        let prev_active_workspace = match origin_index {
+          Some(idx) => active_workspaces.get(
+            idx.checked_sub(1).unwrap_or(active_workspaces.len() - 1),
+          ),
+          None => active_workspaces.last(),
+        };
 
         (
           prev_active_workspace.map(|workspace| workspace.config().name),
@@ -386,16 +392,19 @@ impl WmState {
         )
       }
       WorkspaceTarget::Next => {
-        let workspaces = &config.value.workspaces;
+        let workspaces = &config.filtered_workspaces;
+
         let origin_name = origin_workspace.config().name.clone();
         let origin_index = workspaces
           .iter()
-          .position(|workspace| workspace.name == origin_name)
-          .context("Failed to get index of given workspace.")?;
+          .position(|workspace| workspace.name == origin_name);
 
-        let next_workspace_config = workspaces
-          .get(origin_index + 1)
-          .or_else(|| workspaces.first());
+        let next_workspace_config = match origin_index {
+          Some(idx) => {
+            workspaces.get(idx + 1).or_else(|| workspaces.first())
+          }
+          None => workspaces.first(),
+        };
 
         let next_workspace_name =
           next_workspace_config.map(|config| config.name.clone());
@@ -406,17 +415,20 @@ impl WmState {
 
         (next_workspace_name, next_workspace)
       }
+
       WorkspaceTarget::Previous => {
-        let workspaces = &config.value.workspaces;
+        let workspaces = &config.filtered_workspaces;
+
         let origin_name = origin_workspace.config().name.clone();
         let origin_index = workspaces
           .iter()
-          .position(|workspace| workspace.name == origin_name)
-          .context("Failed to get index of given workspace.")?;
+          .position(|workspace| workspace.name == origin_name);
 
-        let previous_workspace_config = workspaces.get(
-          origin_index.checked_sub(1).unwrap_or(workspaces.len() - 1),
-        );
+        let previous_workspace_config = match origin_index {
+          Some(idx) => workspaces
+            .get(idx.checked_sub(1).unwrap_or(workspaces.len() - 1)),
+          None => workspaces.last(),
+        };
 
         let previous_workspace_name =
           previous_workspace_config.map(|config| config.name.clone());


### PR DESCRIPTION
Hello!
New to rust, wanted to have a property that would allow me to ignore certain workspaces (e.g a workspace which contains installer&setup windows, windows that you might want to keep but ignore their existence for a certain amount of time).

I've just modified the base commands `next-workspace`, `next-active-workspace`, `prev-workspace`, `prev-active-workspace` for the current implementation. Usable with:

```yaml
workspaces:
...
  - name: "setupWindows"
    cycle_ignore: true
```

A better approach might be introducing new commands like `focus --next-active-workspace-with-ignores` to allow the user to cycle without the filter when desired.
Maybe also a command to set, toggle the state of this property?