### PR TITLE
feat: add max_window_width configuration for tiling windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ general:
     # - 'monitor_focus': Jump when focus changes between monitors.
     # - 'window_focus': Jump when focus changes between windows.
     trigger: "monitor_focus"
+
+  # Maximum width for tiling windows. When set, windows will not exceed this
+  # width and will be centered in the available space. Useful for ultra-wide
+  # monitors where you don't want windows to span the entire width.
+  # Example: max_window_width: "1400px" or "80%"
+  # max_window_width: null
 ```
 
 ### Config: Keybindings

--- a/packages/wm-common/src/parsed_config.rs
+++ b/packages/wm-common/src/parsed_config.rs
@@ -93,6 +93,11 @@ pub struct GeneralConfig {
 
   /// Affects which windows get shown in the native Windows taskbar.
   pub show_all_in_taskbar: bool,
+
+  /// Maximum width for tiling windows. When set, windows will not exceed
+  /// this width and will be centered in the available space. Useful for
+  /// ultra-wide monitors.
+  pub max_window_width: Option<LengthValue>,
 }
 
 impl Default for GeneralConfig {
@@ -106,6 +111,7 @@ impl Default for GeneralConfig {
       config_reload_commands: vec![],
       hide_method: HideMethod::Cloak,
       show_all_in_taskbar: false,
+      max_window_width: None,
     }
   }
 }

--- a/packages/wm/src/commands/general/reload_config.rs
+++ b/packages/wm/src/commands/general/reload_config.rs
@@ -144,6 +144,7 @@ fn update_container_gaps(state: &mut WmState, config: &UserConfig) {
 
   for workspace in state.workspaces() {
     workspace.set_gaps_config(config.value.gaps.clone());
+    workspace.set_max_window_width(config.value.general.max_window_width.clone());
   }
 }
 

--- a/packages/wm/src/commands/workspace/activate_workspace.rs
+++ b/packages/wm/src/commands/workspace/activate_workspace.rs
@@ -61,6 +61,7 @@ pub fn activate_workspace(
     workspace_config.clone(),
     config.value.gaps.clone(),
     tiling_direction,
+    config.value.general.max_window_width.clone(),
   );
 
   // Attach the created workspace to the specified monitor.

--- a/packages/wm/src/models/workspace.rs
+++ b/packages/wm/src/models/workspace.rs
@@ -7,8 +7,8 @@ use std::{
 use anyhow::Context;
 use uuid::Uuid;
 use wm_common::{
-  ContainerDto, GapsConfig, Rect, TilingDirection, WorkspaceConfig,
-  WorkspaceDto,
+  ContainerDto, GapsConfig, LengthValue, Rect, TilingDirection,
+  WorkspaceConfig, WorkspaceDto,
 };
 
 use crate::{
@@ -32,6 +32,7 @@ struct WorkspaceInner {
   config: WorkspaceConfig,
   gaps_config: GapsConfig,
   tiling_direction: TilingDirection,
+  max_window_width: Option<LengthValue>,
 }
 
 impl Workspace {
@@ -39,6 +40,7 @@ impl Workspace {
     config: WorkspaceConfig,
     gaps_config: GapsConfig,
     tiling_direction: TilingDirection,
+    max_window_width: Option<LengthValue>,
   ) -> Self {
     let workspace = WorkspaceInner {
       id: Uuid::new_v4(),
@@ -48,6 +50,7 @@ impl Workspace {
       config,
       gaps_config,
       tiling_direction,
+      max_window_width,
     };
 
     Self(Rc::new(RefCell::new(workspace)))
@@ -73,6 +76,14 @@ impl Workspace {
 
   pub fn set_gaps_config(&self, gaps_config: GapsConfig) {
     self.0.borrow_mut().gaps_config = gaps_config;
+  }
+
+  pub fn max_window_width(&self) -> Option<LengthValue> {
+    self.0.borrow().max_window_width.clone()
+  }
+
+  pub fn set_max_window_width(&self, max_window_width: Option<LengthValue>) {
+    self.0.borrow_mut().max_window_width = max_window_width;
   }
 
   pub fn to_dto(&self) -> anyhow::Result<ContainerDto> {

--- a/packages/wm/src/traits/position_getters.rs
+++ b/packages/wm/src/traits/position_getters.rs
@@ -29,6 +29,10 @@ macro_rules! impl_position_getters_as_resizable {
           TilingDirection::Horizontal => horizontal_gap,
         };
 
+        // Cache sibling count to avoid multiple iterations.
+        #[allow(clippy::cast_possible_wrap)]
+        let sibling_count = self.tiling_siblings().count() as i32;
+
         #[allow(
           clippy::cast_precision_loss,
           clippy::cast_possible_truncation,
@@ -37,7 +41,7 @@ macro_rules! impl_position_getters_as_resizable {
         let (width, height) = match parent.tiling_direction() {
           TilingDirection::Vertical => {
             let available_height = parent_rect.height()
-              - inner_gap * self.tiling_siblings().count() as i32;
+              - inner_gap * sibling_count;
 
             let height =
               (self.tiling_size() * available_height as f32) as i32;
@@ -46,7 +50,7 @@ macro_rules! impl_position_getters_as_resizable {
           }
           TilingDirection::Horizontal => {
             let available_width = parent_rect.width()
-              - inner_gap * self.tiling_siblings().count() as i32;
+              - inner_gap * sibling_count;
 
             let width =
               (available_width as f32 * self.tiling_size()).round() as i32;
@@ -55,13 +59,55 @@ macro_rules! impl_position_getters_as_resizable {
           }
         };
 
+        // Apply max_window_width constraint if configured.
+        let (width, x_offset) = if let TilingDirection::Horizontal = parent.tiling_direction() {
+          if let Some(workspace) = self.workspace() {
+            if let Some(max_width) = workspace.max_window_width() {
+              // Get the monitor to use for length calculations.
+              let monitor = workspace.monitor();
+              let scale_factor = monitor
+                .and_then(|m| m.native().scale_factor().ok())
+                .unwrap_or(1.);
+
+              // Convert max_window_width to pixels.
+              let max_width_px = max_width.to_px(parent_rect.width(), Some(scale_factor));
+
+              // Calculate total width if all windows are at max width.
+              // sibling_count is the count of OTHER siblings, so add 1 to include self.
+              let window_count = sibling_count + 1;
+              let total_gaps = inner_gap * sibling_count;  // Gaps between windows
+              let total_max_width = max_width_px * window_count;
+
+              // Only apply constraint if total max width plus gaps fits with room to spare.
+              if total_max_width + total_gaps < parent_rect.width() {
+                // Constrain this window's width to max_width_px.
+                let constrained_width = width.min(max_width_px);
+                
+                // Calculate centering offset for the entire group.
+                let total_constrained_width = total_max_width + total_gaps;
+                let centering_offset = (parent_rect.width() - total_constrained_width) / 2;
+
+                (constrained_width, centering_offset)
+              } else {
+                (width, 0)
+              }
+            } else {
+              (width, 0)
+            }
+          } else {
+            (width, 0)
+          }
+        } else {
+          (width, 0)
+        };
+
         let (x, y) = {
           let mut prev_siblings = self
             .prev_siblings()
             .filter_map(|sibling| sibling.as_tiling_container().ok());
 
           match prev_siblings.next() {
-            None => (parent_rect.x(), parent_rect.y()),
+            None => (parent_rect.x() + x_offset, parent_rect.y()),
             Some(sibling) => {
               let sibling_rect = sibling.to_rect()?;
 

--- a/packages/wm/src/traits/position_getters.rs
+++ b/packages/wm/src/traits/position_getters.rs
@@ -29,10 +29,6 @@ macro_rules! impl_position_getters_as_resizable {
           TilingDirection::Horizontal => horizontal_gap,
         };
 
-        // Cache sibling count to avoid multiple iterations.
-        #[allow(clippy::cast_possible_wrap)]
-        let sibling_count = self.tiling_siblings().count() as i32;
-
         #[allow(
           clippy::cast_precision_loss,
           clippy::cast_possible_truncation,
@@ -41,7 +37,7 @@ macro_rules! impl_position_getters_as_resizable {
         let (width, height) = match parent.tiling_direction() {
           TilingDirection::Vertical => {
             let available_height = parent_rect.height()
-              - inner_gap * sibling_count;
+               - inner_gap * self.tiling_siblings().count() as i32;
 
             let height =
               (self.tiling_size() * available_height as f32) as i32;
@@ -50,7 +46,7 @@ macro_rules! impl_position_getters_as_resizable {
           }
           TilingDirection::Horizontal => {
             let available_width = parent_rect.width()
-              - inner_gap * sibling_count;
+               - inner_gap * self.tiling_siblings().count() as i32;
 
             let width =
               (available_width as f32 * self.tiling_size()).round() as i32;

--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -39,6 +39,12 @@ general:
   # - 'false': Only show windows from the currently shown workspaces.
   show_all_in_taskbar: false
 
+  # Maximum width for tiling windows. When set, windows will not exceed this
+  # width and will be centered in the available space. Useful for ultra-wide
+  # monitors where you don't want windows to span the entire width.
+  # Example: max_window_width: '1400px'
+  # max_window_width: null
+
 gaps:
   # Whether to scale the gaps with the DPI of the monitor.
   scale_with_dpi: true


### PR DESCRIPTION
Closes #1266

Adds the feature described [here ](https://github.com/leftwm/leftwm/issues/475)

This pull request adds support for a new `max_window_width` configuration option, allowing users to set a maximum width for tiling windows—particularly useful for ultra-wide monitors. The implementation ensures that when this option is set, windows will not exceed the specified width and will be centered within the available space. The changes span configuration parsing, workspace state management, and the tiling layout algorithm.

Configuration and Documentation:

* Added the `max_window_width` option to the `general` section in both `README.md` and `sample-config.yaml`, including documentation and usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R123-R128) [[2]](diffhunk://#diff-fa44f5e57e28b4ad0775d9aa5552565e88476d2d0d3d502758b59fb608e9f2dbR42-R47)
* Updated the `GeneralConfig` struct and its default implementation to include the new `max_window_width` field. [[1]](diffhunk://#diff-b1e73b6fda2034aea4f17a4fe01e5d27e918f73c1330f83331cbcf0f9f80d4e5R96-R100) [[2]](diffhunk://#diff-b1e73b6fda2034aea4f17a4fe01e5d27e918f73c1330f83331cbcf0f9f80d4e5R114)

Workspace and State Management:

* Propagated the `max_window_width` setting through workspace creation and reload logic, ensuring each workspace receives and stores this configuration. [[1]](diffhunk://#diff-657ca2fb33bae34044d65d005f36e482d85581e53a4fb4ead885cf50d05006daR147) [[2]](diffhunk://#diff-a39059abe344c76ecbbadf7c176797207462f2ee23a4e5e50d71f3ee17d3f8cfR64) [[3]](diffhunk://#diff-667106ed08bc52716401ffc9a23c8e441de077cb339a4bee7cc612ab6cc537b4L10-R11) [[4]](diffhunk://#diff-667106ed08bc52716401ffc9a23c8e441de077cb339a4bee7cc612ab6cc537b4R35-R43) [[5]](diffhunk://#diff-667106ed08bc52716401ffc9a23c8e441de077cb339a4bee7cc612ab6cc537b4R53) [[6]](diffhunk://#diff-667106ed08bc52716401ffc9a23c8e441de077cb339a4bee7cc612ab6cc537b4R81-R88)

Tiling Layout Algorithm:

* Enhanced the tiling layout logic to respect the `max_window_width` constraint: windows are limited in width and centered if the total width of all windows plus gaps is less than the workspace width. This logic is applied only in horizontal tiling mode. [[1]](diffhunk://#diff-8b87526fc58188f15e7ccb75b0723c4fc6096a506e118eaf19834b4e32253f5fR32-R35) [[2]](diffhunk://#diff-8b87526fc58188f15e7ccb75b0723c4fc6096a506e118eaf19834b4e32253f5fL40-R44) [[3]](diffhunk://#diff-8b87526fc58188f15e7ccb75b0723c4fc6096a506e118eaf19834b4e32253f5fL49-R53) [[4]](diffhunk://#diff-8b87526fc58188f15e7ccb75b0723c4fc6096a506e118eaf19834b4e32253f5fR62-R110)