### PR TITLE
feat: per-monitor gap overrides

### DIFF
--- a/packages/wm-common/src/parsed_config.rs
+++ b/packages/wm-common/src/parsed_config.rs
@@ -47,8 +47,48 @@ pub struct GapsConfig {
   pub outer_gap: RectDelta,
 
   /// Gap between window and the screen edge if there is only one window
-  /// in the workspace
+  /// in the workspace.
   pub single_window_outer_gap: Option<RectDelta>,
+
+  /// Per-monitor overrides for `outer_gap` (and optionally
+  /// `single_window_outer_gap`). Monitors can be matched by index
+  /// (0-based, left-to-right) or device name.
+  #[serde(default)]
+  pub monitor_outer_gap: Vec<MonitorOuterGapConfig>,
+}
+
+impl GapsConfig {
+  /// Returns a `GapsConfig` with outer gaps resolved for the given
+  /// monitor. If a matching `monitor_outer_gap` entry exists, its values
+  /// override the global `outer_gap` and `single_window_outer_gap`.
+  pub fn for_monitor(
+    &self,
+    monitor_index: usize,
+    device_name: &str,
+  ) -> Self {
+    let override_config =
+      self
+        .monitor_outer_gap
+        .iter()
+        .find(|entry| match &entry.monitor {
+          MonitorSelector::Index(idx) => *idx as usize == monitor_index,
+          MonitorSelector::Name(name) => name == device_name,
+        });
+
+    match override_config {
+      Some(entry) => GapsConfig {
+        scale_with_dpi: self.scale_with_dpi,
+        inner_gap: self.inner_gap.clone(),
+        outer_gap: entry.outer_gap.clone(),
+        single_window_outer_gap: entry
+          .single_window_outer_gap
+          .clone()
+          .or_else(|| self.single_window_outer_gap.clone()),
+        monitor_outer_gap: vec![],
+      },
+      None => self.clone(),
+    }
+  }
 }
 
 impl Default for GapsConfig {
@@ -63,8 +103,33 @@ impl Default for GapsConfig {
         LengthValue::from_px(0),
       ),
       single_window_outer_gap: None,
+      monitor_outer_gap: vec![],
     }
   }
+}
+
+/// Identifies a monitor by index or device name.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum MonitorSelector {
+  Index(u32),
+  Name(String),
+}
+
+/// Per-monitor override for outer gap configuration.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct MonitorOuterGapConfig {
+  /// Monitor to apply the override to, either by index (0-based,
+  /// left-to-right) or by device name string.
+  pub monitor: MonitorSelector,
+
+  /// Gap between windows and the screen edge for this monitor.
+  pub outer_gap: RectDelta,
+
+  /// Override for single-window outer gap on this monitor.
+  #[serde(default)]
+  pub single_window_outer_gap: Option<RectDelta>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/packages/wm-common/src/parsed_config.rs
+++ b/packages/wm-common/src/parsed_config.rs
@@ -50,41 +50,49 @@ pub struct GapsConfig {
   /// in the workspace.
   pub single_window_outer_gap: Option<RectDelta>,
 
-  /// Per-monitor overrides for `outer_gap` (and optionally
-  /// `single_window_outer_gap`). Monitors can be matched by index
-  /// (0-based, left-to-right) or device name.
+  /// Per-monitor gap overrides. Each entry can selectively override
+  /// `inner_gap`, `outer_gap`, and/or `single_window_outer_gap`.
+  /// Monitors are matched by index (0-based, left-to-right) or device
+  /// name.
   #[serde(default)]
-  pub monitor_outer_gap: Vec<MonitorOuterGapConfig>,
+  pub monitor_overrides: Vec<MonitorGapOverride>,
 }
 
 impl GapsConfig {
-  /// Returns a `GapsConfig` with outer gaps resolved for the given
-  /// monitor. If a matching `monitor_outer_gap` entry exists, its values
-  /// override the global `outer_gap` and `single_window_outer_gap`.
+  /// Returns a `GapsConfig` with gaps resolved for the given monitor.
+  /// If a matching `monitor_overrides` entry exists, its values override
+  /// the corresponding global gap settings.
+  #[must_use]
   pub fn for_monitor(
     &self,
     monitor_index: usize,
     device_name: &str,
   ) -> Self {
-    let override_config =
+    let override_entry =
       self
-        .monitor_outer_gap
+        .monitor_overrides
         .iter()
         .find(|entry| match &entry.monitor {
           MonitorSelector::Index(idx) => *idx as usize == monitor_index,
           MonitorSelector::Name(name) => name == device_name,
         });
 
-    match override_config {
+    match override_entry {
       Some(entry) => GapsConfig {
         scale_with_dpi: self.scale_with_dpi,
-        inner_gap: self.inner_gap.clone(),
-        outer_gap: entry.outer_gap.clone(),
+        inner_gap: entry
+          .inner_gap
+          .clone()
+          .unwrap_or_else(|| self.inner_gap.clone()),
+        outer_gap: entry
+          .outer_gap
+          .clone()
+          .unwrap_or_else(|| self.outer_gap.clone()),
         single_window_outer_gap: entry
           .single_window_outer_gap
           .clone()
           .or_else(|| self.single_window_outer_gap.clone()),
-        monitor_outer_gap: vec![],
+        monitor_overrides: vec![],
       },
       None => self.clone(),
     }
@@ -103,7 +111,7 @@ impl Default for GapsConfig {
         LengthValue::from_px(0),
       ),
       single_window_outer_gap: None,
-      monitor_outer_gap: vec![],
+      monitor_overrides: vec![],
     }
   }
 }
@@ -116,18 +124,24 @@ pub enum MonitorSelector {
   Name(String),
 }
 
-/// Per-monitor override for outer gap configuration.
+/// Per-monitor gap override. All gap fields are optional and fall back
+/// to the corresponding global value when omitted.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
-pub struct MonitorOuterGapConfig {
-  /// Monitor to apply the override to, either by index (0-based,
-  /// left-to-right) or by device name string.
+pub struct MonitorGapOverride {
+  /// Monitor to match, either by index (0-based, left-to-right) or
+  /// by device name string.
   pub monitor: MonitorSelector,
 
-  /// Gap between windows and the screen edge for this monitor.
-  pub outer_gap: RectDelta,
+  /// Override for the gap between adjacent windows.
+  #[serde(default)]
+  pub inner_gap: Option<LengthValue>,
 
-  /// Override for single-window outer gap on this monitor.
+  /// Override for the gap between windows and the screen edge.
+  #[serde(default)]
+  pub outer_gap: Option<RectDelta>,
+
+  /// Override for the single-window outer gap.
   #[serde(default)]
   pub single_window_outer_gap: Option<RectDelta>,
 }

--- a/packages/wm/src/commands/general/reload_config.rs
+++ b/packages/wm/src/commands/general/reload_config.rs
@@ -141,8 +141,8 @@ fn update_workspace_configs(
 
 /// Updates outer gap of workspaces and inner gaps of tiling containers.
 ///
-/// Workspace gaps are resolved per-monitor when `monitor_outer_gap`
-/// overrides are present in the config.
+/// Workspace gaps are resolved per-monitor when `monitor_overrides`
+/// are present in the config.
 fn update_container_gaps(state: &mut WmState, config: &UserConfig) {
   let tiling_containers = state
     .root_container
@@ -154,15 +154,15 @@ fn update_container_gaps(state: &mut WmState, config: &UserConfig) {
   }
 
   for workspace in state.workspaces() {
-    let gaps = workspace
-      .monitor()
-      .map(|monitor| {
+    let gaps = workspace.monitor().map_or_else(
+      || config.value.gaps.clone(),
+      |monitor| {
         config.value.gaps.for_monitor(
           monitor.index(),
           &monitor.native_properties().device_name,
         )
-      })
-      .unwrap_or_else(|| config.value.gaps.clone());
+      },
+    );
 
     workspace.set_gaps_config(gaps);
   }

--- a/packages/wm/src/commands/general/reload_config.rs
+++ b/packages/wm/src/commands/general/reload_config.rs
@@ -140,6 +140,9 @@ fn update_workspace_configs(
 }
 
 /// Updates outer gap of workspaces and inner gaps of tiling containers.
+///
+/// Workspace gaps are resolved per-monitor when `monitor_outer_gap`
+/// overrides are present in the config.
 fn update_container_gaps(state: &mut WmState, config: &UserConfig) {
   let tiling_containers = state
     .root_container
@@ -151,7 +154,17 @@ fn update_container_gaps(state: &mut WmState, config: &UserConfig) {
   }
 
   for workspace in state.workspaces() {
-    workspace.set_gaps_config(config.value.gaps.clone());
+    let gaps = workspace
+      .monitor()
+      .map(|monitor| {
+        config.value.gaps.for_monitor(
+          monitor.index(),
+          &monitor.native_properties().device_name,
+        )
+      })
+      .unwrap_or_else(|| config.value.gaps.clone());
+
+    workspace.set_gaps_config(gaps);
   }
 }
 

--- a/packages/wm/src/commands/general/reload_config.rs
+++ b/packages/wm/src/commands/general/reload_config.rs
@@ -150,7 +150,16 @@ fn update_container_gaps(state: &mut WmState, config: &UserConfig) {
     .filter_map(|container| container.as_tiling_container().ok());
 
   for container in tiling_containers {
-    container.set_gaps_config(config.value.gaps.clone());
+    let gaps = container.monitor().map_or_else(
+      || config.value.gaps.clone(),
+      |monitor| {
+        config.value.gaps.for_monitor(
+          monitor.index(),
+          &monitor.native_properties().device_name,
+        )
+      },
+    );
+    container.set_gaps_config(gaps);
   }
 
   for workspace in state.workspaces() {

--- a/packages/wm/src/commands/monitor/add_monitor.rs
+++ b/packages/wm/src/commands/monitor/add_monitor.rs
@@ -105,6 +105,13 @@ pub fn move_workspace_to_monitor(
     state,
   )?;
 
+  // Update the workspace's gap config to match the target monitor.
+  let target_gaps = config.value.gaps.for_monitor(
+    target_monitor.index(),
+    &target_monitor.native_properties().device_name,
+  );
+  workspace.set_gaps_config(target_gaps);
+
   let windows = workspace
     .descendants()
     .filter_map(|descendant| descendant.as_window_container().ok());

--- a/packages/wm/src/commands/monitor/remove_monitor.rs
+++ b/packages/wm/src/commands/monitor/remove_monitor.rs
@@ -34,13 +34,19 @@ pub fn remove_monitor(
     });
 
   for workspace in workspaces_to_move {
-    // Move workspace to target monitor.
     move_container_within_tree(
       &workspace.clone().into(),
       &target_monitor.clone().into(),
       target_monitor.child_count(),
       state,
     )?;
+
+    // Update the workspace's gap config to match the target monitor.
+    let target_gaps = config.value.gaps.for_monitor(
+      target_monitor.index(),
+      &target_monitor.native_properties().device_name,
+    );
+    workspace.set_gaps_config(target_gaps);
 
     sort_workspaces(&target_monitor, config)?;
 

--- a/packages/wm/src/commands/window/manage_window.rs
+++ b/packages/wm/src/commands/window/manage_window.rs
@@ -165,7 +165,10 @@ fn create_window(
     .displayed_workspace()
     .context("No nearest workspace.")?;
 
-  let gaps_config = config.value.gaps.clone();
+  let gaps_config = config.value.gaps.for_monitor(
+    nearest_monitor.index(),
+    &nearest_monitor.native_properties().device_name,
+  );
   let window_state =
     window_state_to_create(&native_properties, &nearest_monitor, config)?;
 

--- a/packages/wm/src/commands/window/move_window_in_direction.rs
+++ b/packages/wm/src/commands/window/move_window_in_direction.rs
@@ -295,10 +295,18 @@ fn invert_workspace_tiling_direction(
   // we create a split container around 1 and 2. This results in
   // H[H[1 V[2 3]]], and V[H[1 V[2]] 3] after the tiling direction change.
   if workspace_children.len() > 1 {
-    let split_container = SplitContainer::new(
-      workspace.tiling_direction(),
-      config.value.gaps.clone(),
+    let gaps = workspace.monitor().map_or_else(
+      || config.value.gaps.clone(),
+      |monitor| {
+        config.value.gaps.for_monitor(
+          monitor.index(),
+          &monitor.native_properties().device_name,
+        )
+      },
     );
+
+    let split_container =
+      SplitContainer::new(workspace.tiling_direction(), gaps);
 
     wrap_in_split_container(
       &split_container,

--- a/packages/wm/src/commands/workspace/activate_workspace.rs
+++ b/packages/wm/src/commands/workspace/activate_workspace.rs
@@ -57,11 +57,13 @@ pub fn activate_workspace(
     TilingDirection::Horizontal
   };
 
-  let workspace = Workspace::new(
-    workspace_config.clone(),
-    config.value.gaps.clone(),
-    tiling_direction,
+  let gaps = config.value.gaps.for_monitor(
+    target_monitor.index(),
+    &target_monitor.native_properties().device_name,
   );
+
+  let workspace =
+    Workspace::new(workspace_config.clone(), gaps, tiling_direction);
 
   // Attach the created workspace to the specified monitor.
   attach_container(

--- a/packages/wm/src/commands/workspace/move_workspace_in_direction.rs
+++ b/packages/wm/src/commands/workspace/move_workspace_in_direction.rs
@@ -34,6 +34,13 @@ pub fn move_workspace_in_direction(
       state,
     )?;
 
+    // Update the workspace's gap config to match the target monitor.
+    let target_gaps = config.value.gaps.for_monitor(
+      target_monitor.index(),
+      &target_monitor.native_properties().device_name,
+    );
+    workspace.set_gaps_config(target_gaps);
+
     let windows = workspace
       .descendants()
       .filter_map(|descendant| descendant.as_window_container().ok());


### PR DESCRIPTION
Adds `monitor_overrides` to `GapsConfig`, allowing per-monitor overrides for `inner_gap`, `outer_gap`, and `single_window_outer_gap`. Monitors can be matched by index (0-based, left-to-right) or device name. All override fields are optional and fall back to the global value when omitted.

Closes #1231

## Config example

```yaml
gaps:
  inner_gap: '10px'
  outer_gap:
    top: '45px'
    right: '5px'
    bottom: '5px'
    left: '5px'
  single_window_outer_gap:
    top: '10px'
    right: '0px'
    bottom: '0px'
    left: '0px'
  monitor_overrides:
    - monitor: 0            # by index
      outer_gap:
        top: '12px'
        right: '5px'
        bottom: '5px'
        left: '5px'
      single_window_outer_gap:
        top: '0px'
        right: '0px'
        bottom: '0px'
        left: '0px'
    - monitor: 'DELL U2722D'  # or by device name
      outer_gap:
        top: '50px'
        right: '10px'
        bottom: '10px'
        left: '10px'
    - monitor: 2              # override only inner_gap
      inner_gap: '20px'
```

## Motivation

On multi-monitor setups — especially macOS with a MacBook notch display — different monitors need different gap configurations. The built-in display (with zebar docked behind the notch) needs a small top gap, while external monitors need a larger gap to clear the status bar. Single-window gaps may also differ per monitor.

This is similar to [AeroSpace's per-monitor gap config](https://nikitabobko.github.io/AeroSpace/guide):
```toml
outer.top = [
  { monitor."built-in" = 10 },
  50
]
```

## Changes

- **`wm-common/parsed_config.rs`**: Added `MonitorSelector` enum, `MonitorGapOverride` struct with optional `inner_gap`/`outer_gap`/`single_window_outer_gap`, `monitor_overrides` field on `GapsConfig`, and `for_monitor()` resolution method
- **`wm/commands/workspace/activate_workspace.rs`**: Resolve per-monitor gaps when creating a workspace
- **`wm/commands/general/reload_config.rs`**: Resolve per-monitor gaps for both workspaces and tiling containers when reloading config
- **`wm/commands/monitor/remove_monitor.rs`**: Update workspace gap config when workspaces move due to monitor disconnect
- **`wm/commands/monitor/add_monitor.rs`**: Update workspace gap config when workspaces move to a newly connected monitor
- **`wm/commands/workspace/move_workspace_in_direction.rs`**: Update workspace gap config on manual `move-workspace` between monitors
- **`wm/commands/window/manage_window.rs`**: Create tiling windows with per-monitor gap config
- **`wm/commands/window/move_window_in_direction.rs`**: Create split containers with per-monitor gap config

Fully backward compatible — `monitor_overrides` defaults to an empty vec.
