### PR TITLE
fix: re-detect windows after AXUIElementDestroyed on macOS

### DIFF
--- a/packages/wm-platform/src/platform_impl/macos/application_observer.rs
+++ b/packages/wm-platform/src/platform_impl/macos/application_observer.rs
@@ -296,6 +296,90 @@ impl ApplicationObserver {
             err
           );
         }
+
+        // Re-enumerate the application's windows after a short delay
+        // to catch replacements whose `AXWindowCreated` notification
+        // was missed (e.g. Spotify rapidly destroys and recreates its
+        // window on launch).
+        //
+        // The re-enumeration is dispatched back to the event loop
+        // thread so that AX notifications can be registered for any
+        // newly discovered windows.
+
+        // SAFETY: The `ApplicationEventContext` is heap-allocated via
+        // `Box::into_raw` and lives for the lifetime of the
+        // `ApplicationObserver`. Passing the address as `usize` keeps
+        // the closure `Send`.
+        let context_addr =
+          std::ptr::from_ref::<ApplicationEventContext>(context) as usize;
+        let dispatcher = context.application.dispatcher.clone();
+        let pid = context.application.pid;
+
+        std::thread::spawn(move || {
+          std::thread::sleep(std::time::Duration::from_millis(500));
+
+          let result = dispatcher.dispatch_sync(move || {
+            // SAFETY: See comment above — pointer is stable and the
+            // closure runs on the event loop thread.
+            let context = unsafe {
+              &*(context_addr as *const ApplicationEventContext)
+            };
+
+            let current_windows = match context.application.windows() {
+              Ok(w) => w,
+              Err(err) => {
+                tracing::debug!(
+                  "Re-enumeration failed for PID {}: {}",
+                  pid,
+                  err,
+                );
+                return;
+              }
+            };
+
+            let mut tracked = context.app_windows.lock().unwrap();
+
+            for new_window in current_windows {
+              if tracked.iter().any(|w| w.id() == new_window.id()) {
+                continue;
+              }
+
+              tracing::info!(
+                "Re-discovered window {} for PID {} after destroy.",
+                new_window.id().0,
+                pid,
+              );
+
+              tracked.push(new_window.clone());
+
+              if let Err(err) = Self::register_window_notifications(
+                &new_window,
+                &context.observer,
+                context_addr as *mut ApplicationEventContext,
+              ) {
+                tracing::warn!(
+                  "Failed to register notifications for \
+                   re-discovered window {}: {}",
+                  new_window.id().0,
+                  err,
+                );
+              }
+
+              let _ = context.events_tx.send(WindowEvent::Shown {
+                window: new_window,
+                notification: crate::WindowEventNotification(None),
+              });
+            }
+          });
+
+          if let Err(err) = result {
+            tracing::debug!(
+              "Failed to dispatch re-enumeration for PID {}: {}",
+              pid,
+              err,
+            );
+          }
+        });
       }
 
       return;

--- a/packages/wm-platform/src/platform_impl/macos/window_listener.rs
+++ b/packages/wm-platform/src/platform_impl/macos/window_listener.rs
@@ -172,19 +172,38 @@ impl WindowListener {
         NotificationEvent::WorkspaceDidActivateApplication(
           running_app,
         ) => {
-          let Ok(Ok(Some(focused_window))) =
-            dispatcher.dispatch_sync(|| {
-              let app = Application::new(running_app, dispatcher.clone());
-              app.focused_window()
-            })
-          else {
-            continue;
-          };
+          let pid = running_app.processIdentifier();
 
-          let _ = events_tx.send(WindowEvent::Focused {
-            window: focused_window,
-            notification: crate::WindowEventNotification(None),
-          });
+          // Create an observer if one doesn't exist yet. This handles
+          // apps that create their window before
+          // `WorkspaceDidLaunchApplication` is processed.
+          if let std::collections::hash_map::Entry::Vacant(entry) =
+            app_observers.entry(pid)
+          {
+            let events_tx = events_tx.clone();
+
+            if let Ok(Ok(app_observer)) = dispatcher.dispatch_sync(|| {
+              let app = Application::new(running_app, dispatcher.clone());
+              ApplicationObserver::new(&app, events_tx.clone(), false)
+            }) {
+              entry.insert(app_observer);
+            }
+          } else {
+            let Ok(Ok(Some(focused_window))) =
+              dispatcher.dispatch_sync(|| {
+                let app =
+                  Application::new(running_app, dispatcher.clone());
+                app.focused_window()
+              })
+            else {
+              continue;
+            };
+
+            let _ = events_tx.send(WindowEvent::Focused {
+              window: focused_window,
+              notification: crate::WindowEventNotification(None),
+            });
+          }
         }
         NotificationEvent::WorkspaceDidHideApplication(running_app) => {
           if let Some(app_observer) =

--- a/packages/wm/src/commands/window/manage_window.rs
+++ b/packages/wm/src/commands/window/manage_window.rs
@@ -92,6 +92,10 @@ fn check_is_manageable(
   native_window: &NativeWindow,
 ) -> anyhow::Result<Option<NativeWindowProperties>> {
   if !native_window.is_visible()? {
+    tracing::debug!(
+      "Window {} not manageable: not visible.",
+      native_window.id().0,
+    );
     return Ok(None);
   }
 
@@ -99,10 +103,18 @@ fn check_is_manageable(
   {
     use wm_platform::NativeWindowExtMacOs;
 
-    let is_standard_window = native_window.role()? == "AXWindow"
-      && native_window.subrole()? == "AXStandardWindow";
+    let role = native_window.role()?;
+    let subrole = native_window.subrole()?;
+    let is_standard_window =
+      role == "AXWindow" && subrole == "AXStandardWindow";
 
     if !is_standard_window {
+      tracing::debug!(
+        "Window {} not manageable: role={}, subrole={}.",
+        native_window.id().0,
+        role,
+        subrole,
+      );
       return Ok(None);
     }
   }


### PR DESCRIPTION
## Summary

Some apps (e.g. Spotify) rapidly destroy and recreate their window on launch. The `AXWindowCreated` notification for the replacement window can be missed, leaving the window unmanaged.

## Changes

**1. Post-destroy re-enumeration with AX notification registration**

After `AXUIElementDestroyed`, a delayed (500ms) re-enumeration of the application's windows catches missed replacements. The re-enumeration is dispatched to the event loop thread via `dispatcher.dispatch_sync()` so that `register_window_notifications()` can be called for newly discovered windows — ensuring they respond to all future AX events (moves, resizes, title changes, destruction).

**2. Observer creation on `WorkspaceDidActivateApplication`**

Creates an observer if one doesn't exist yet when an application is activated, handling apps that create their window before `WorkspaceDidLaunchApplication` is processed.

**3. Diagnostic logging in `check_is_manageable`**

Added `tracing::debug!` to the silent rejection paths (`not visible`, `non-standard role/subrole`) for future diagnostics.

## Tested

Confirmed working with Spotify on macOS — window destroy/recreate cycle properly re-tiles and the re-discovered window responds to subsequent events:

```
09:02:11 New window managed: Window(id=9775, process=Spotify, title=Klangkuenstler)
09:02:15 Window closed: Window(id=9775, process=Spotify)
09:02:17 New window managed: Window(id=9813, process=Spotify, title=Spotify Premium)
09:02:25 Window closed: Window(id=9813, process=Spotify)
09:02:27 New window managed: Window(id=9833, process=Spotify, title=Spotify Premium)
09:02:43 Window manually focused: Window(id=9833, process=Spotify)
```