### PR TITLE
fix: handle native macOS tab groups in window management

### DIFF
--- a/packages/wm-platform/src/native_window.rs
+++ b/packages/wm-platform/src/native_window.rs
@@ -98,6 +98,18 @@ pub trait NativeWindowExtMacOs {
   ///
   /// This method is only available on macOS.
   fn is_main(&self) -> crate::Result<bool>;
+
+  /// Whether this window is a root window (not a background tab).
+  ///
+  /// Background tabs in native macOS tab groups have an `AXWindow`
+  /// parent instead of an `AXApplication` parent.
+  fn is_root_window(&self) -> crate::Result<bool>;
+
+  /// Gets the process ID of the owning application.
+  fn process_id(&self) -> i32;
+
+  /// Re-queries the current `CGWindowID` from the `AXUIElement`.
+  fn current_window_id(&self) -> crate::Result<WindowId>;
 }
 
 #[cfg(target_os = "macos")]
@@ -136,6 +148,18 @@ impl NativeWindowExtMacOs for NativeWindow {
       el.get_attribute::<CFBoolean>("AXMain")
         .map(|cf_bool| cf_bool.value())
     })?
+  }
+
+  fn is_root_window(&self) -> crate::Result<bool> {
+    self.inner.is_root_window()
+  }
+
+  fn process_id(&self) -> i32 {
+    self.inner.process_id()
+  }
+
+  fn current_window_id(&self) -> crate::Result<WindowId> {
+    self.inner.current_window_id()
   }
 }
 

--- a/packages/wm-platform/src/platform_impl/macos/native_window.rs
+++ b/packages/wm-platform/src/platform_impl/macos/native_window.rs
@@ -167,6 +167,37 @@ impl NativeWindow {
     )
   }
 
+  /// Whether this window is a root window (not a background tab).
+  ///
+  /// Native macOS tabs share the same physical window frame, but each
+  /// tab is a separate `AXUIElement`. A background tab's `AXParent`
+  /// points to another `AXWindow` (the active tab), whereas a root
+  /// window's `AXParent` points to the `AXApplication`.
+  pub(crate) fn is_root_window(&self) -> crate::Result<bool> {
+    self.element.with(|el| {
+      let parent = el.get_attribute::<AXUIElement>("AXParent")?;
+      let parent_role = parent.get_attribute::<CFString>("AXRole")?;
+
+      Ok(parent_role.to_string() != "AXWindow")
+    })?
+  }
+
+  /// Gets the process ID of the application that owns this window.
+  pub(crate) fn process_id(&self) -> platform_impl::ProcessId {
+    self.application.pid
+  }
+
+  /// Re-queries the current `CGWindowID` from the underlying
+  /// `AXUIElement`.
+  ///
+  /// For native macOS tab groups, the `CGWindowID` changes on tab
+  /// switch even though the `AXUIElement` stays the same.
+  pub(crate) fn current_window_id(&self) -> crate::Result<WindowId> {
+    self
+      .element
+      .with(|el| Ok(WindowId::from_window_element(el)))?
+  }
+
   /// Implements [`NativeWindow::set_frame`].
   pub(crate) fn set_frame(&self, rect: &Rect) -> crate::Result<()> {
     // TODO: Consider adding a separate `set_frame_async` method which

--- a/packages/wm/src/commands/window/manage_window.rs
+++ b/packages/wm/src/commands/window/manage_window.rs
@@ -105,6 +105,15 @@ fn check_is_manageable(
     if !is_standard_window {
       return Ok(None);
     }
+
+    // Skip background tabs in native macOS tab groups.
+    if !native_window.is_root_window().unwrap_or(true) {
+      tracing::debug!(
+        "Window {} not manageable: background tab.",
+        native_window.id().0,
+      );
+      return Ok(None);
+    }
   }
 
   // Ensure window has a valid process name, title, etc.

--- a/packages/wm/src/events/handle_window_shown.rs
+++ b/packages/wm/src/events/handle_window_shown.rs
@@ -1,10 +1,13 @@
 use tracing::info;
-use wm_common::{DisplayState, HideMethod};
+use wm_common::{DisplayState, HideMethod, WindowState};
 use wm_platform::NativeWindow;
 
 use crate::{
-  commands::window::manage_window, traits::WindowGetters,
-  user_config::UserConfig, wm_state::WmState,
+  commands::window::manage_window,
+  models::{NativeWindowProperties, WindowContainer},
+  traits::{CommonGetters, WindowGetters},
+  user_config::UserConfig,
+  wm_state::WmState,
 };
 
 pub fn handle_window_shown(
@@ -25,10 +28,84 @@ pub fn handle_window_shown(
     } else {
       state.pending_sync.queue_container_to_redraw(window);
     }
+  } else if let Some(old_tab) = find_background_tab(&native_window, state)
+  {
+    swap_tab_window(old_tab, native_window, state)?;
   } else {
-    // If the window is not managed, manage it.
     manage_window(native_window, None, state, config)?;
   }
+
+  Ok(())
+}
+
+/// Finds a managed window from the same process that has become a
+/// background tab (i.e. is no longer a root window).
+#[cfg(target_os = "macos")]
+fn find_background_tab(
+  new_window: &NativeWindow,
+  state: &WmState,
+) -> Option<WindowContainer> {
+  use wm_platform::NativeWindowExtMacOs;
+
+  let new_pid = new_window.process_id();
+
+  state.windows().into_iter().find(|window| {
+    let is_same_process = window.native().process_id() == new_pid;
+    let is_background_tab =
+      is_same_process && !window.native().is_root_window().unwrap_or(true);
+
+    is_background_tab
+  })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn find_background_tab(
+  _new_window: &NativeWindow,
+  _state: &WmState,
+) -> Option<WindowContainer> {
+  None
+}
+
+/// Replaces a background tab's native window reference with the newly
+/// active tab, preserving the window's position in the layout tree.
+fn swap_tab_window(
+  old_tab: WindowContainer,
+  new_native: NativeWindow,
+  state: &mut WmState,
+) -> anyhow::Result<()> {
+  let new_properties = NativeWindowProperties::try_from(&new_native)?;
+
+  info!(
+    "Tab switch: replacing {} (handle {}) with new tab (handle {})",
+    old_tab,
+    old_tab.native().id().0,
+    new_native.id().0,
+  );
+
+  old_tab.set_native(new_native);
+  old_tab.update_native_properties(|props| {
+    props.title = new_properties.title;
+    props.frame = new_properties.frame;
+    props.is_minimized = new_properties.is_minimized;
+    props.is_maximized = new_properties.is_maximized;
+    props.is_resizable = new_properties.is_resizable;
+  });
+
+  // Redraw the window at its existing position/size. For tiling
+  // windows this reapplies the tiled frame; for floating windows this
+  // reapplies the stored floating placement.
+  match old_tab.state() {
+    WindowState::Tiling => {
+      if let Some(parent) = old_tab.parent() {
+        state.pending_sync.queue_container_to_redraw(parent);
+      }
+    }
+    _ => {
+      state.pending_sync.queue_container_to_redraw(old_tab);
+    }
+  }
+
+  state.pending_sync.queue_focus_change();
 
   Ok(())
 }

--- a/packages/wm/src/events/handle_window_title_changed.rs
+++ b/packages/wm/src/events/handle_window_title_changed.rs
@@ -23,7 +23,25 @@ pub fn handle_window_title_changed(
       properties.title = title;
     });
 
-    // Run window rules for title change events.
+    // Native macOS tab switches reuse the same `AXUIElement` but
+    // change the underlying `CGWindowID`. Detect this and queue a
+    // redraw so the newly active tab gets positioned correctly.
+    #[cfg(target_os = "macos")]
+    {
+      use wm_platform::NativeWindowExtMacOs;
+
+      if let Ok(current_id) = native_window.current_window_id() {
+        if current_id != native_window.id() {
+          info!(
+            "Tab switch detected for {window}: {} -> {}",
+            native_window.id().0,
+            current_id.0,
+          );
+          state.pending_sync.queue_container_to_redraw(window.clone());
+        }
+      }
+    }
+
     run_window_rules(
       window,
       &WindowRuleEvent::TitleChange,

--- a/packages/wm/src/traits/window_getters.rs
+++ b/packages/wm/src/traits/window_getters.rs
@@ -60,6 +60,8 @@ pub trait WindowGetters: CommonGetters {
 
   fn native(&self) -> Ref<'_, NativeWindow>;
 
+  fn set_native(&self, native: NativeWindow);
+
   fn border_delta(&self) -> RectDelta;
 
   fn set_border_delta(&self, border_delta: RectDelta);
@@ -195,6 +197,10 @@ macro_rules! impl_window_getters {
 
       fn native(&self) -> Ref<'_, NativeWindow> {
         Ref::map(self.0.borrow(), |inner| &inner.native)
+      }
+
+      fn set_native(&self, native: NativeWindow) {
+        self.0.borrow_mut().native = native;
       }
 
       fn border_delta(&self) -> RectDelta {


### PR DESCRIPTION
## Summary

- Fixes native macOS tab groups (e.g. Fork, Finder) being managed as independent windows, causing invisible tiling slots and incorrect sizing
- Background tabs are now detected via `AXParent` attribute and excluded from management
- Tab switches are detected via `CGWindowID` change on title change events, triggering a redraw at the existing tree position

## Problem

macOS native tabs share a physical window frame, but each tab is a separate `CGWindow`/`AXUIElement`. Without tab awareness:
- Background tabs were managed as separate tiling windows, taking up invisible layout space
- Switching tabs created ghost windows or sizing mismatches
- The active tab's frame could be wrong (e.g. 1024×768 on a 3440×1440 monitor)

## Approach

**Single-window model**: treat a tab group as one managed window, swapping the native handle on tab switch.

### Platform layer (`wm-platform`)
- `is_root_window()` — checks `AXParent` to distinguish active tab (parent=`AXApplication`) from background tab (parent=`AXWindow`)
- `current_window_id()` — re-queries `CGWindowID` from `AXUIElement`, since tab switches change the ID without changing the element
- `process_id()` — exposes PID for same-process matching
- `set_native()` — allows swapping the `NativeWindow` reference inside the WM container

### WM layer
- `check_is_manageable()` — skips background tabs at startup via `is_root_window()`
- `handle_window_shown()` — detects tab switch via same-PID background tab detection; swaps native handle instead of manage/unmanage churn
- `handle_window_title_changed()` — detects `CGWindowID` change (tab switch signal) and queues redraw

## Testing

Tested with Fork (native macOS tabs):
- ✅ Only active tab managed at startup
- ✅ Tab switch preserves tiling position and size
- ✅ No invisible ghost windows in layout