### PR TITLE
fix: re-capture display properties after settling to fix stale working area

### DIFF
--- a/packages/wm-platform/src/platform_impl/macos/display_listener.rs
+++ b/packages/wm-platform/src/platform_impl/macos/display_listener.rs
@@ -85,6 +85,22 @@ impl DisplayListener {
       // take 1-2 seconds to be reported as online.
       const WAKE_COALESCE_DURATION: Duration = Duration::from_secs(5);
 
+      // Delay before re-capturing display properties to let macOS
+      // settle (e.g. menu bar auto-hide re-engaging after a display
+      // reconfiguration).
+      const SETTLED_RECAPTURE_DELAY: Duration = Duration::from_millis(500);
+
+      // Fire an initial event so that display properties are
+      // re-captured shortly after startup, correcting any transient
+      // `NSScreen.visibleFrame` values captured during launch.
+      {
+        let tx = event_tx.clone();
+        std::thread::spawn(move || {
+          std::thread::sleep(SETTLED_RECAPTURE_DELAY);
+          let _ = tx.send(());
+        });
+      }
+
       let mut is_asleep = false;
       let mut wake_time: Option<Instant> = None;
 
@@ -134,6 +150,17 @@ impl DisplayListener {
               );
               break;
             }
+
+            // Schedule a follow-up event to correct transient
+            // `NSScreen.visibleFrame` values. With menu bar auto-hide,
+            // macOS may briefly show the menu bar during display
+            // reconfiguration and does not fire another notification
+            // once it re-hides (~300-500ms later).
+            let tx = event_tx.clone();
+            std::thread::spawn(move || {
+              std::thread::sleep(SETTLED_RECAPTURE_DELAY);
+              let _ = tx.send(());
+            });
           }
           _ => {}
         }


### PR DESCRIPTION
## Summary

- Schedule a follow-up display change event 500ms after each reconfiguration to re-capture `NSScreen.visibleFrame` once macOS has settled
- Also fire one at startup to correct any transient values from the initial capture
- Fixes an intermittent gap between the top bar and tiled windows on the primary monitor

## Problem

With menu bar auto-hide enabled, macOS may briefly show the menu bar during display reconfiguration (monitor connect/disconnect) or at launch. `NSScreen.visibleFrame` captured at that moment includes the menu bar offset (~25-37px), but macOS does **not** fire another `NSApplicationDidChangeScreenParametersNotification` once the menu bar re-hides. The stale `working_area` offset is then added to the user's `outer_gap`, creating an unexpected gap on the primary monitor.

The issue is intermittent because it depends on whether the menu bar happens to be visible at capture time. It only affects the primary monitor (secondary monitors have no menu bar). Windows is unaffected because the taskbar working area is stable.

## Solution

Re-use the existing delayed-event pattern (already used for wake coalescing) to schedule a follow-up `DisplaySettingsChanged` event 500ms after:

1. **Each display reconfiguration** — by the time the follow-up fires, the menu bar auto-hide animation (~300ms) has completed and `visibleFrame` reflects the true usable area
2. **Startup** — corrects any transient values from the initial `populate()` capture

The handler (`handle_display_settings_changed`) already handles redundant events gracefully — if the re-captured properties match the stored ones, the redraw is effectively a no-op.

## Research

- **yabai** avoids `NSScreen` entirely, using private SkyLight/CG APIs for menu bar geometry
- **Amethyst** uses `NSApplicationDidChangeScreenParametersNotification` (same as GlazeWM) but subscribes to additional menu bar change notifications
- **AeroSpace** lazily re-reads `NSScreen` on every refresh session
- Apple docs confirm the menu bar auto-hide state is not part of the screen parameters notification cycle