### PR TITLE
feat: support maximized fullscreen via native macOS fullscreen

### DIFF
--- a/packages/wm-platform/src/native_window.rs
+++ b/packages/wm-platform/src/native_window.rs
@@ -98,6 +98,9 @@ pub trait NativeWindowExtMacOs {
   ///
   /// This method is only available on macOS.
   fn is_main(&self) -> crate::Result<bool>;
+
+  /// Exits native macOS fullscreen by setting `AXFullScreen` to `false`.
+  fn unmaximize(&self) -> crate::Result<()>;
 }
 
 #[cfg(target_os = "macos")]
@@ -136,6 +139,10 @@ impl NativeWindowExtMacOs for NativeWindow {
       el.get_attribute::<CFBoolean>("AXMain")
         .map(|cf_bool| cf_bool.value())
     })?
+  }
+
+  fn unmaximize(&self) -> crate::Result<()> {
+    self.inner.unmaximize()
   }
 }
 

--- a/packages/wm-platform/src/platform_impl/macos/native_window.rs
+++ b/packages/wm-platform/src/platform_impl/macos/native_window.rs
@@ -225,6 +225,14 @@ impl NativeWindow {
     })?
   }
 
+  /// Implements [`NativeWindowExtMacOs::unmaximize`].
+  pub(crate) fn unmaximize(&self) -> crate::Result<()> {
+    self.element.with(move |el| -> crate::Result<()> {
+      let ax_bool = CFBoolean::new(false);
+      el.set_attribute::<CFBoolean>("AXFullScreen", &ax_bool.into())
+    })?
+  }
+
   /// Implements [`NativeWindow::focus`].
   pub(crate) fn focus(&self) -> crate::Result<()> {
     let psn = self.application.psn()?;

--- a/packages/wm/src/commands/general/platform_sync.rs
+++ b/packages/wm/src/commands/general/platform_sync.rs
@@ -5,6 +5,8 @@ use wm_common::{
   CursorJumpTrigger, DisplayState, HideCorner, HideMethod, UniqueExt,
   WindowState, WmEvent,
 };
+#[cfg(target_os = "macos")]
+use wm_platform::NativeWindowExtMacOs;
 #[cfg(target_os = "windows")]
 use wm_platform::NativeWindowWindowsExt;
 #[cfg(target_os = "windows")]
@@ -335,6 +337,7 @@ fn redraw_containers(
   Ok(())
 }
 
+#[allow(clippy::too_many_lines)]
 fn reposition_window(
   window: &WindowContainer,
   hide_corner: HideCorner,
@@ -388,7 +391,38 @@ fn reposition_window(
     window.native().resize(rect.width(), rect.height())?;
   } else {
     #[cfg(target_os = "macos")]
-    window.native().set_frame(&rect)?;
+    {
+      // Exit native macOS fullscreen if the window is natively maximized
+      // but shouldn't be (e.g. transitioning to tiling/floating).
+      let should_unmaximize = match &window.state() {
+        WindowState::Fullscreen(fs) => {
+          !fs.maximized && window.native().is_maximized()?
+        }
+        _ => window.native().is_maximized()?,
+      };
+
+      if should_unmaximize {
+        if let Err(err) = window.native().unmaximize() {
+          tracing::warn!("Failed to exit native fullscreen: {}", err);
+        }
+      }
+
+      // Enter native macOS fullscreen if maximized fullscreen is
+      // requested. Skip `set_frame` since macOS manages the window
+      // geometry in native fullscreen.
+      if matches!(
+        &window.state(),
+        WindowState::Fullscreen(fs) if fs.maximized
+      ) {
+        if !window.native().is_maximized()? {
+          if let Err(err) = window.native().maximize() {
+            tracing::warn!("Failed to enter native fullscreen: {}", err);
+          }
+        }
+      } else {
+        window.native().set_frame(&rect)?;
+      }
+    }
 
     #[cfg(target_os = "windows")]
     {


### PR DESCRIPTION
## Summary

- When `fullscreen.maximized` is `true` on macOS, enters native fullscreen (`AXFullScreen`) instead of sizing to the working area — allowing the window to cover the entire screen including the menu bar/notch area.
- Handles the reverse transition: exits native fullscreen when the window state changes away from maximized fullscreen.

## Problem

On macOS, `fullscreen.maximized: true` was a no-op — the maximized code path in `reposition_window` only existed for Windows. The macOS fullscreen always used `working_area` (via `NSScreen.visibleFrame`), which excludes the menu bar. Due to the notch on modern MacBooks, macOS's Accessibility API constrains window placement to below the menu bar, making it impossible to cover the full screen via `set_frame` alone.

## Changes

- **`wm-platform` (macOS)**: Added `unmaximize()` method to `NativeWindow` and `NativeWindowExtMacOs` trait, which sets `AXFullScreen` to `false`.
- **`wm` (`platform_sync.rs`)**: Added macOS handling in `reposition_window`:
  - **Enter**: When state is `Fullscreen { maximized: true }` and window isn't natively maximized, calls `maximize()` (native macOS fullscreen). Skips `set_frame` since macOS manages window geometry.
  - **Exit**: When the window is natively maximized but the state no longer requires it, calls `unmaximize()` before proceeding with normal `set_frame`.