### PR TITLE
feat: add monocle mode for workspaces

### DIFF
--- a/packages/wm-common/src/app_command.rs
+++ b/packages/wm-common/src/app_command.rs
@@ -260,6 +260,8 @@ pub enum InvokeCommand {
   WmRedraw,
   WmReloadConfig,
   WmTogglePause,
+  ToggleMonocle,
+  SetMonocle,
 }
 
 impl<'de> Deserialize<'de> for InvokeCommand {
@@ -431,4 +433,7 @@ pub struct InvokeUpdateWorkspaceConfig {
 
   #[clap(long)]
   pub keep_alive: Option<bool>,
+
+  #[clap(long)]
+  pub monocle: Option<bool>,
 }

--- a/packages/wm-common/src/dtos/workspace_dto.rs
+++ b/packages/wm-common/src/dtos/workspace_dto.rs
@@ -23,4 +23,5 @@ pub struct WorkspaceDto {
   pub x: i32,
   pub y: i32,
   pub tiling_direction: TilingDirection,
+  pub is_monocle: bool,
 }

--- a/packages/wm-common/src/parsed_config.rs
+++ b/packages/wm-common/src/parsed_config.rs
@@ -385,6 +385,9 @@ pub struct WorkspaceConfig {
 
   #[serde(default = "default_bool::<false>")]
   pub keep_alive: bool,
+
+  #[serde(default = "default_bool::<false>")]
+  pub monocle: bool,
 }
 
 /// Helper function for setting a default value for a boolean field.

--- a/packages/wm/src/commands/window/update_window_state.rs
+++ b/packages/wm/src/commands/window/update_window_state.rs
@@ -27,6 +27,15 @@ pub fn update_window_state(
     return Ok(window);
   }
 
+  if matches!(target_state, WindowState::Fullscreen(_)) {
+    if let Some(workspace) = window.workspace() {
+      if workspace.is_monocle() {
+        info!("Blocking fullscreen in monocle workspace.");
+        return Ok(window);
+      }
+    }
+  }
+
   info!("Updating window state: {:?}.", target_state);
 
   match target_state {

--- a/packages/wm/src/commands/workspace/update_workspace_config.rs
+++ b/packages/wm/src/commands/workspace/update_workspace_config.rs
@@ -38,6 +38,7 @@ pub fn update_workspace_config(
       .bind_to_monitor
       .or(current_config.bind_to_monitor),
     keep_alive: new_config.keep_alive.unwrap_or(current_config.keep_alive),
+    monocle: new_config.monocle.unwrap_or(current_config.monocle),
   };
 
   workspace.set_config(updated_config);

--- a/packages/wm/src/events/handle_window_moved_or_resized.rs
+++ b/packages/wm/src/events/handle_window_moved_or_resized.rs
@@ -268,6 +268,12 @@ pub fn handle_window_moved_or_resized(
 
     // Handle a window being maximized or entering fullscreen.
     if is_maximized || should_fullscreen {
+      if let Some(workspace) = window.workspace() {
+        if workspace.is_monocle() {
+          let _ = window.native().restore(None);
+          return Ok(());
+        }
+      }
       let is_same_state = is_maximized
         && matches!(
           window.state(),

--- a/packages/wm/src/events/handle_window_moved_or_resized.rs
+++ b/packages/wm/src/events/handle_window_moved_or_resized.rs
@@ -270,6 +270,7 @@ pub fn handle_window_moved_or_resized(
     if is_maximized || should_fullscreen {
       if let Some(workspace) = window.workspace() {
         if workspace.is_monocle() {
+          #[cfg(target_os = "windows")]
           let _ = window.native().restore(None);
           return Ok(());
         }

--- a/packages/wm/src/models/workspace.rs
+++ b/packages/wm/src/models/workspace.rs
@@ -32,6 +32,7 @@ struct WorkspaceInner {
   config: WorkspaceConfig,
   gaps_config: GapsConfig,
   tiling_direction: TilingDirection,
+  is_monocle: bool,
 }
 
 impl Workspace {
@@ -40,6 +41,7 @@ impl Workspace {
     gaps_config: GapsConfig,
     tiling_direction: TilingDirection,
   ) -> Self {
+    let is_monocle = config.monocle;
     let workspace = WorkspaceInner {
       id: Uuid::new_v4(),
       parent: None,
@@ -48,6 +50,7 @@ impl Workspace {
       config,
       gaps_config,
       tiling_direction,
+      is_monocle,
     };
 
     Self(Rc::new(RefCell::new(workspace)))
@@ -111,21 +114,14 @@ impl Workspace {
       1.
     };
 
-    // Get the delta between the monitor's bounds and its working area.
-    let monitor_bounds = monitor.native_properties().bounds;
-    let working_area_delta = monitor
-      .native_properties()
-      .working_area
-      .delta(&monitor_bounds);
+    // Use the monitor's working area (excludes taskbar) as the base.
+    let working_area = monitor.native_properties().working_area;
 
     Ok(
-      monitor_bounds
+      working_area
         // Scale the gaps if `scale_with_dpi` is enabled. Outer gap config
-        // values can be a percentage (relative to the monitor bounds), so
-        // the outer gap delta needs to be applied prior to the working
-        // area delta.
-        .apply_delta(&outer_gaps.inverse(), Some(scale_factor))
-        .apply_delta(&working_area_delta, None),
+        // values can be a percentage (relative to the monitor bounds).
+        .apply_delta(&outer_gaps.inverse(), Some(scale_factor)),
     )
   }
 
@@ -173,7 +169,16 @@ impl Workspace {
       x: rect.x(),
       y: rect.y(),
       tiling_direction: self.tiling_direction(),
+      is_monocle: self.is_monocle(),
     }))
+  }
+
+  pub fn is_monocle(&self) -> bool {
+    self.0.borrow().is_monocle
+  }
+
+  pub fn set_monocle(&self, new_state: bool) {
+    self.0.borrow_mut().is_monocle = new_state;
   }
 }
 

--- a/packages/wm/src/traits/position_getters.rs
+++ b/packages/wm/src/traits/position_getters.rs
@@ -16,6 +16,11 @@ macro_rules! impl_position_getters_as_resizable {
   ($struct_name:ident) => {
     impl PositionGetters for $struct_name {
       fn to_rect(&self) -> anyhow::Result<Rect> {
+        if let Some(workspace) = self.workspace() {
+          if workspace.is_monocle() {
+            return workspace.to_rect();
+          }
+        }
         let parent = self
           .parent()
           .and_then(|parent| parent.as_direction_container().ok())

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -779,7 +779,13 @@ impl WindowManager {
       InvokeCommand::ToggleMonocle => {
         let workspace =
           subject_container.workspace().context("No workspace.")?;
-        workspace.set_monocle(!workspace.is_monocle());
+        let new_monocle_state = !workspace.is_monocle();
+        workspace.set_monocle(new_monocle_state);
+
+        if new_monocle_state {
+          exit_fullscreen_windows(&workspace, state, config)?;
+        }
+
         state
           .pending_sync
           .queue_container_to_redraw(workspace.clone());
@@ -789,6 +795,7 @@ impl WindowManager {
         let workspace =
           subject_container.workspace().context("No workspace.")?;
         workspace.set_monocle(true);
+        exit_fullscreen_windows(&workspace, state, config)?;
         state
           .pending_sync
           .queue_container_to_redraw(workspace.clone());
@@ -830,4 +837,36 @@ impl WindowManager {
       }
     }
   }
+}
+
+/// Changes all fullscreen windows in the workspace to normal state.
+///
+/// This is needed when enabling monocle mode to ensure consistent window
+/// behavior. Fullscreen windows would otherwise behave differently than
+/// other windows in monocle mode.
+fn exit_fullscreen_windows(
+  workspace: &crate::models::Workspace,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<()> {
+  use crate::traits::CommonGetters;
+
+  let fullscreen_windows: Vec<_> = workspace
+    .self_and_descendants()
+    .filter_map(|container| container.as_window_container().ok())
+    .filter(|window| matches!(window.state(), WindowState::Fullscreen(_)))
+    .collect();
+
+  for window in fullscreen_windows {
+    let target_state = window.toggled_state(WindowState::Tiling, config);
+    if let Err(err) =
+      update_window_state(window, target_state, state, config)
+    {
+      if !err.to_string().contains("Window has no workspace.") {
+        return Err(err);
+      }
+    }
+  }
+
+  Ok(())
 }

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -776,6 +776,24 @@ impl WindowManager {
         toggle_pause(state);
         Ok(())
       }
+      InvokeCommand::ToggleMonocle => {
+        let workspace =
+          subject_container.workspace().context("No workspace.")?;
+        workspace.set_monocle(!workspace.is_monocle());
+        state
+          .pending_sync
+          .queue_container_to_redraw(workspace.clone());
+        Ok(())
+      }
+      InvokeCommand::SetMonocle => {
+        let workspace =
+          subject_container.workspace().context("No workspace.")?;
+        workspace.set_monocle(true);
+        state
+          .pending_sync
+          .queue_container_to_redraw(workspace.clone());
+        Ok(())
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Introduce a new workspace mode that restricts windows to a single fullscreen layout. This prevents manual window state changes and automatically restores windows that attempt to maximize or enter fullscreen.

## Changes

- Add `ToggleMonocle` and `SetMonocle` invoke commands
- Add `monocle` option to workspace configuration and DTOs
- Block fullscreen transitions in monocle workspaces
- Restore window state on maximize/fullscreen attempts in monocle mode
- Use monitor working area as base for workspace bounds calculation

## Testing

Tested manually on Windows 10 OS.

## Open questions

- For Windows I used following logic `window.native().restore(None);`. I'm not sure how such case should be handled for MacOS.

## Related PRs

Closes #1210 

Idea based on #478 
