### PR TITLE
feat: add move-cursor command to warp cursor to focused window

### DIFF
--- a/packages/wm-common/src/app_command.rs
+++ b/packages/wm-common/src/app_command.rs
@@ -159,6 +159,7 @@ pub enum InvokeCommand {
   Close,
   Focus(InvokeFocusCommand),
   Ignore,
+  MoveCursor(InvokeMoveCursorCommand),
   Move(InvokeMoveCommand),
   MoveWorkspace {
     #[clap(long)]
@@ -344,6 +345,14 @@ pub struct InvokeFocusCommand {
 
   #[clap(long)]
   pub recent_workspace: bool,
+}
+
+#[derive(Args, Clone, Debug, PartialEq, Serialize)]
+#[group(required = true, multiple = false)]
+pub struct InvokeMoveCursorCommand {
+  /// Move the cursor to the center of the currently focused window.
+  #[clap(long)]
+  pub direction: Option<Direction>,
 }
 
 #[derive(Args, Clone, Debug, PartialEq, Serialize)]

--- a/packages/wm/src/commands/general/mod.rs
+++ b/packages/wm/src/commands/general/mod.rs
@@ -1,6 +1,7 @@
 mod cycle_focus;
 mod disable_binding_mode;
 mod enable_binding_mode;
+mod move_cursor;
 mod platform_sync;
 mod reload_config;
 mod shell_exec;
@@ -9,6 +10,7 @@ mod toggle_pause;
 pub use cycle_focus::*;
 pub use disable_binding_mode::*;
 pub use enable_binding_mode::*;
+pub use move_cursor::*;
 pub use platform_sync::*;
 pub use reload_config::*;
 pub use shell_exec::*;

--- a/packages/wm/src/commands/general/move_cursor.rs
+++ b/packages/wm/src/commands/general/move_cursor.rs
@@ -1,0 +1,28 @@
+use crate::{
+  traits::{CommonGetters, PositionGetters},
+  wm_state::WmState,
+};
+
+/// Moves the cursor to the center of the currently focused window.
+///
+/// Does nothing if no window is currently focused (e.g. an empty workspace
+/// is focused instead).
+pub fn move_cursor_to_active_window(
+  state: &WmState,
+) -> anyhow::Result<()> {
+  let Some(focused) = state.focused_container() else {
+    return Ok(());
+  };
+
+  if focused.as_window_container().is_err() {
+    return Ok(());
+  }
+
+  let center = focused.to_rect()?.center_point();
+
+  if let Err(err) = state.dispatcher.set_cursor_position(&center) {
+    tracing::warn!("Failed to move cursor: {}.", err);
+  }
+
+  Ok(())
+}

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -22,7 +22,8 @@ use crate::{
     },
     general::{
       cycle_focus, disable_binding_mode, enable_binding_mode,
-      platform_sync, reload_config, shell_exec, toggle_pause,
+      move_cursor_to_active_window, platform_sync, reload_config,
+      shell_exec, toggle_pause,
     },
     monitor::focus_monitor,
     window::{
@@ -335,6 +336,12 @@ impl WindowManager {
           Ok(window) => ignore_window(window, state),
           _ => Ok(()),
         }
+      }
+      InvokeCommand::MoveCursor(args) => {
+        if args.direction.is_some() {
+          move_cursor_to_active_window(state)?;
+        }
+        Ok(())
       }
       InvokeCommand::Move(args) => {
         match subject_container.as_window_container() {


### PR DESCRIPTION
Adds a new `move-cursor --direction left` so the cursor only warps on explicit keyboard-driven focus changes, not mouse clicks or workspace switches.

This makes it so you can use your mouse more freely and only activate the window cursor warp when you use certain keybinds.