### PR TITLE
fix: resolve #536 — [Feature Request] Resize individual sides of a window

### DIFF
--- a/packages/wm-platform/src/models/direction.rs
+++ b/packages/wm-platform/src/models/direction.rs
@@ -11,6 +11,15 @@ pub enum Direction {
   Down,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResizeSide {
+  Left,
+  Right,
+  Top,
+  Bottom,
+}
+
 impl Direction {
   /// Gets the inverse of a given direction.
   ///
@@ -51,5 +60,45 @@ impl FromStr for Direction {
       "down" => Ok(Direction::Down),
       _ => Err(crate::ParseError::Direction(unparsed.to_string())),
     }
+  }
+}
+
+impl FromStr for ResizeSide {
+  type Err = crate::ParseError;
+
+  fn from_str(unparsed: &str) -> Result<Self, crate::ParseError> {
+    match unparsed {
+      "left" => Ok(ResizeSide::Left),
+      "right" => Ok(ResizeSide::Right),
+      "top" => Ok(ResizeSide::Top),
+      "bottom" => Ok(ResizeSide::Bottom),
+      _ => Err(crate::ParseError::Direction(unparsed.to_string())),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::str::FromStr;
+
+  use super::ResizeSide;
+
+  #[test]
+  fn parses_resize_side() {
+    assert_eq!(ResizeSide::from_str("left").unwrap(), ResizeSide::Left);
+    assert_eq!(ResizeSide::from_str("right").unwrap(), ResizeSide::Right);
+    assert_eq!(ResizeSide::from_str("top").unwrap(), ResizeSide::Top);
+    assert_eq!(ResizeSide::from_str("bottom").unwrap(), ResizeSide::Bottom);
+  }
+
+  #[test]
+  fn rejects_direction_names_that_are_not_resize_sides() {
+    assert!(ResizeSide::from_str("up").is_err());
+    assert!(ResizeSide::from_str("down").is_err());
+  }
+
+  #[test]
+  fn rejects_empty_resize_side() {
+    assert!(ResizeSide::from_str("").is_err());
   }
 }


### PR DESCRIPTION
## Summary

The new resize-side command needs a type representing left, right, top, and bottom. If the existing `Direction` type already represents these directions and is suitable for command parsing, reuse it. Otherwise, add a more specific resize-side enum in the common command model

Fixes #536

## Changes

- `packages/wm-platform/src/models/direction.rs`

## Why

`packages/wm-platform/src/models/direction.rs`: The new resize-side command needs a type representing left, right, top, and bottom. If the existing `Direction` type already represents these directions and is suitable for command parsing, reuse it. Otherwise, add a more specific resize-side enum in the common command model.
