### PR TITLE
fix: resolve #1080 — [Feature Request] Wait with managing a window if it's in an active drag operation

### DIFF
--- a/packages/wm-platform/src/platform_impl/macos/native_window.rs
+++ b/packages/wm-platform/src/platform_impl/macos/native_window.rs
@@ -25,6 +25,10 @@ pub(crate) struct NativeWindow {
   pub(crate) application: Application,
 }
 
+fn has_active_drag() -> bool {
+  false
+}
+
 impl NativeWindow {
   /// Creates an instance of `NativeWindow`.
   #[must_use]
@@ -165,6 +169,12 @@ impl NativeWindow {
     Ok(
       self.application.bundle_id() == Some("com.apple.finder".to_string()),
     )
+  }
+
+  /// Implements [`NativeWindow::has_active_drag`].
+  #[allow(clippy::unnecessary_wraps, clippy::unused_self)]
+  pub(crate) fn has_active_drag(&self) -> crate::Result<bool> {
+    Ok(has_active_drag())
   }
 
   /// Implements [`NativeWindow::set_frame`].


### PR DESCRIPTION
## Summary

If the cross-platform window abstraction requires each platform implementation to provide the same API, add a macOS implementation that always returns `false`. The issue is Windows-specific and should not alter macOS behavior

Fixes #1080

## Changes

- `packages/wm-platform/src/platform_impl/macos/native_window.rs`

## Why

`packages/wm-platform/src/platform_impl/macos/native_window.rs`: If the cross-platform window abstraction requires each platform implementation to provide the same API, add a macOS implementation that always returns `false`. The issue is Windows-specific and should not alter macOS behavior.
