### PR TITLE
Restore windows to their original state on GlazeWM exit

### DIFF
--- a/packages/wm/src/models/native_window_properties.rs
+++ b/packages/wm/src/models/native_window_properties.rs
@@ -9,8 +9,14 @@ pub struct NativeWindowProperties {
   pub class_name: String,
   pub process_name: String,
   pub frame: Rect,
+  /// The window's original position/size before GlazeWM managed it.
+  /// Used to restore windows to their initial state when the WM exits.
+  pub original_frame: Rect,
   pub is_minimized: bool,
   pub is_maximized: bool,
+  /// Whether the window was originally maximized before GlazeWM managed it.
+  /// Used to restore maximized state when the WM exits.
+  pub original_is_maximized: bool,
   pub is_resizable: bool,
   #[cfg(target_os = "windows")]
   pub shadow_borders: RectDelta,
@@ -20,14 +26,18 @@ impl TryFrom<&NativeWindow> for NativeWindowProperties {
   type Error = anyhow::Error;
 
   fn try_from(native_window: &NativeWindow) -> Result<Self, Self::Error> {
+    let frame = native_window.frame()?;
+
     Ok(Self {
       title: native_window.title()?,
       #[cfg(target_os = "windows")]
       class_name: native_window.class_name()?,
       process_name: native_window.process_name()?,
-      frame: native_window.frame()?,
+      frame: frame.clone(),
+      original_frame: frame,
       is_minimized: native_window.is_minimized()?,
       is_maximized: native_window.is_maximized()?,
+      original_is_maximized: native_window.is_maximized()?,
       is_resizable: native_window.is_resizable()?,
       #[cfg(target_os = "windows")]
       shadow_borders: native_window.shadow_borders()?,

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -686,12 +686,33 @@ impl Drop for WmState {
     let managed_windows = self.windows();
 
     for window in &managed_windows {
-      // Redraw windows to their intended positions. On macOS, this will
-      // unhide windows that are on other workspaces.
-      if let Ok(rect) = window.to_rect() {
-        if let Err(err) = window.native().set_frame(&rect) {
-          warn!("Failed to redraw window on cleanup: {:?}", err);
+      let native_props = window.native_properties();
+      let original_frame = native_props.original_frame;
+
+      // Restore windows to their original position/size from before
+      // GlazeWM managed them. Unhides windows that are on other
+      // workspaces (macOS) or restores initial layout on exit.
+      //
+      // On Windows, if the window was originally maximized, we set the
+      // restored-size frame first, then maximize it to fully restore the
+      // original state.
+      #[cfg(target_os = "windows")]
+      {
+        if native_props.original_is_maximized {
+          // First set the normal (restored) position so that the window
+          // knows its unmaximized bounds, then maximize.
+          let _ = window.native().restore(Some(&original_frame));
+          let _ = window.native().maximize();
+        } else if let Err(err) =
+          window.native().set_frame(&original_frame)
+        {
+          warn!("Failed to restore window frame on cleanup: {:?}", err);
         }
+      }
+
+      #[cfg(not(target_os = "windows"))]
+      if let Err(err) = window.native().set_frame(&original_frame) {
+        warn!("Failed to restore window frame on cleanup: {:?}", err);
       }
 
       // Reset any effects on Windows.


### PR DESCRIPTION
fix: Restore windows to their original state on GlazeWM exit

Summary

This PR fixes a long-standing issue where windows are left in their tiled positions (and lose their maximized state) when GlazeWM exits. Previously, on shutdown, windows were redrawn at their WM-managed layout positions instead of being restored to where they were before GlazeWM started.

Problem

When GlazeWM exits, all managed windows remain in the positions assigned by the tiling layout. Maximized/fullscreen windows permanently lose their maximized state — they are left as non-maximized windows at their tiled size/position, disrupting the user's desktop layout.

Changes

1. Snapshot original window state at startup

**`packages/wm/src/models/native_window_properties.rs`**:
- Added `original_frame: Rect` — captures the window's frame position and size before GlazeWM takes over management. This is populated once during initial state population via `TryFrom<&NativeWindow>`.
- Added `original_is_maximized: bool` — records whether the window was originally maximized before being converted to tiling mode.

 2. Restore windows on exit

**`packages/wm/src/wm_state.rs`** — `Drop for WmState`:
- Instead of redrawing windows at their tiled positions (`window.to_rect()`), the `Drop` implementation now restores each window using its cached `original_frame`.
- **On Windows**: Windows that were originally maximized are restored using `restore(Some(&original_frame))` to set the normal bounds, followed by `maximize()` to restore the maximized state. Non-maximized windows use `set_frame(&original_frame)`.
- Effects (borders, transparency, taskbar visibility) are still reset as before.
- This also unhides windows that were on other workspaces (macOS).

## Testing

- Verified that windows return to their exact original position and size after `exit`.
- Confirmed that maximized windows are properly restored to maximized state (not left as tiled non-maximized windows).
- Builds cleanly with no new dependencies.