### PR TITLE
fix: make system tray icon monochrome

### DIFF
--- a/packages/wm/src/sys_tray.rs
+++ b/packages/wm/src/sys_tray.rs
@@ -186,11 +186,15 @@ impl SystemTray {
       "../../../resources/assets/icon.png"
     ))?;
 
-    let tray_icon = TrayIconBuilder::new()
+    let builder = TrayIconBuilder::new()
       .with_menu(Box::new(tray_menu))
       .with_tooltip(format!("GlazeWM v{}", env!("VERSION_NUMBER")))
-      .with_icon(icon)
-      .build()?;
+      .with_icon(icon);
+
+    #[cfg(target_os = "macos")]
+    let builder = builder.with_icon_as_template(true);
+
+    let tray_icon = builder.build()?;
 
     Ok(tray_icon)
   }


### PR DESCRIPTION
### Summary
This PR configures the system tray icon to render as a template on macOS, making it monochrome and allowing it to adapt dynamically to macOS light/dark themes.

### Details
- Configures `TrayIconBuilder::with_icon_as_template(true)` using conditional compilation (`#[cfg(target_os = "macos")]`).
- Using conditional compilation is necessary since `with_icon_as_template` is only defined on the macOS target in the `tray-icon` crate; calling it directly on Windows targets would result in compilation failures.

Closes #1395
