### PR TITLE
fix: handle quoted arguments in shell-exec on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,6 +3297,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shell-util",
+ "shlex",
  "tauri-winres",
  "tokio",
  "tokio-tungstenite",

--- a/packages/wm/Cargo.toml
+++ b/packages/wm/Cargo.toml
@@ -29,6 +29,7 @@ image = "0.25"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = "0.9"
+shlex = "1.3"
 shell-util = "0.0"
 tokio = { workspace = true }
 tokio-tungstenite = { workspace = true }

--- a/packages/wm/src/commands/general/shell_exec.rs
+++ b/packages/wm/src/commands/general/shell_exec.rs
@@ -9,6 +9,13 @@ use wm_platform::DispatcherExtWindows;
 
 use crate::wm_state::WmState;
 
+/// Splits a shell argument string respecting single and double quotes.
+/// Returns `None` if the string contains unmatched quotes.
+#[cfg(target_os = "macos")]
+fn split_shell_args(args: &str) -> Option<Vec<String>> {
+  shlex::split(args)
+}
+
 pub fn shell_exec(
   command: &str,
   // LINT: `hide_window` is only used on Windows.
@@ -30,9 +37,11 @@ pub fn shell_exec(
   let result = {
     #[cfg(target_os = "macos")]
     {
+      let parsed_args = split_shell_args(&args)
+        .unwrap_or_else(|| args.split_whitespace().map(String::from).collect());
       Shell::spawn(
         &program,
-        args.split_whitespace(),
+        parsed_args,
         &CommandOptions::default(),
       )
     }


### PR DESCRIPTION
## Summary

Fixes `shell-exec` on macOS to properly handle quoted arguments (e.g. app names with spaces).

## Problem

On macOS, `shell-exec` splits arguments on whitespace without respecting shell-style quotes. This causes commands like:

```yaml
- "shell-exec open -a \"Microsoft Outlook\""
```

to fail because `"Microsoft Outlook"` gets split into `"Microsoft` and `Outlook"` as separate arguments.

## Solution

Use [`shlex::split`](https://docs.rs/shlex) to parse the arguments string with proper shell quoting rules before passing them to `Shell::spawn`. Falls back to whitespace splitting if `shlex` can't parse the input (e.g. unmatched quotes).

The `shlex` crate is a well-established, pure-Rust implementation of POSIX shell quoting (already a transitive dependency in the lockfile).

## Changes

- `packages/wm/Cargo.toml`: Add `shlex = "1.3"` dependency
- `packages/wm/src/commands/general/shell_exec.rs`:
  - Add `split_shell_args()` helper (macOS-only, gated with `#[cfg(target_os = "macos")]`)
  - Replace `args.split_whitespace()` with `split_shell_args(&args)` in the macOS `Shell::spawn` call

## Testing

- `cargo check --package wm` passes
- `cargo test --package wm` passes (2 existing tests)
- Verified the fix handles: double-quoted args, single-quoted args, unquoted args, and mixed quoting

## Related

Fixes #1337