### PR TITLE
chore: Add macOS installation via Homebrew to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ scoop bucket add extras
 scoop install extras/glazewm
 ```
 
+**Homebrew (macOS)**
+
+```sh
+brew install --cask glzr-io/tap/glazewm glzr-io/tap/zebar
+```
+
 ## Contributing
 
 Help fix something that annoys you, or add a feature you've been wanting for a long time! Contributions are very welcome.

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -83,7 +83,7 @@ impl UserConfig {
       config_path.parent().context("Invalid config path.")?;
 
     fs::create_dir_all(parent_dir).with_context(|| {
-      format!("Unable to create directory {}.", &config_path.display())
+      format!("Unable to create directory {}.", config_path.display())
     })?;
 
     fs::write(config_path, SAMPLE_CONFIG).with_context(|| {


### PR DESCRIPTION
## Summary

GlazeWM v3.10.0 added macOS support, but the README only listed Windows package managers. This adds Homebrew installation instructions to match the release notes.