### PR TITLE
feat: declarative column layouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3335,6 +3335,7 @@ dependencies = [
  "clap",
  "regex",
  "serde",
+ "serde_yaml",
  "tracing",
  "uuid",
  "wm-platform",

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ GlazeWM lets you easily organize windows and adjust their layout on the fly by u
 - Simple YAML configuration
 - Multi-monitor support
 - Customizable rules for specific windows
+- Declarative centered-focus column layouts
 - Easy one-click installation
 - Integration with [Zebar](https://github.com/glzr-io/zebar) as a status bar
 
@@ -256,6 +257,74 @@ workspaces:
     # Optionally prevent workspace from being deactivated when empty.
     keep_alive: false
 ```
+
+### Config: Columns
+
+Columns turn a workspace into a **centered-focus layout**: the focused window sits in a wide center column, with supporting windows tiled into columns on either side. The layout is declarative — you describe the shape once and GlazeWM keeps it applied as windows open, close, and move.
+
+A column `spec` is a comma-separated, left-to-right list of columns. Each token is one column:
+
+- `C` — the wide **center** column, holding the focused window. Exactly one `C` is required.
+- a **number** (`1`, `2`, `3`, …) — a *fixed* stack holding exactly that many windows.
+- `*` — a *flexible* stack that shares out whatever windows the fixed columns don't take, split evenly across all `*` columns.
+
+Columns fill left-to-right. Say you have six windows open (one focused, five others):
+
+| Spec | Columns | Result |
+| --- | --- | --- |
+| `*,C,*` | flexible \| **center** \| flexible | `3 \| C \| 2` — the five side windows split evenly; the odd one goes left (see `bias`). |
+| `2,C,*` | fixed 2 \| **center** \| flexible | `2 \| C \| 3` — the left column is capped at two, the right takes the rest. |
+| `C,*,*` | **center** \| flexible \| flexible | `C \| 3 \| 2` — center on the left, the other five split across two columns. |
+| `C,2,*` | **center** \| fixed 2 \| flexible | `C \| 2 \| 3` — center, then a fixed pair, then everything else. |
+
+If the fixed columns can't hold every window and there's no `*` to absorb the rest, the extra windows stack onto the last column so none are dropped.
+
+**Column widths.** `center` sets the center column's width as a fraction of the workspace (`0.1`–`0.9`, default `0.6`). The rest of the width is split **equally** among the other columns, no matter how many windows each one stacks — so `C,*,*` at `center: 0.6` gives a 60% center and two 20% columns, while `2,C,*` gives a 60% center with 20% columns either side. Within a column, the stacked windows share its height evenly.
+
+**Per-workspace layout.** A workspace can pin its own layout via the `columns` property, reapplied automatically whenever the workspace is focused or its windows change:
+
+```yaml
+workspaces:
+  - name: "1"
+    # A bare spec string...
+    columns: "*,C,*"
+
+  - name: "2"
+    # ...or a full object.
+    columns:
+      spec: "C,2,*"    # Center, a fixed pair, then the rest.
+      center: 0.6      # Center width as a fraction of the workspace (default 0.6).
+      bias: "left"     # Which side wins an uneven `*` split (default "left").
+```
+
+**Default by monitor shape.** `general.default_columns` applies a layout to any workspace without its own `columns`, chosen from the aspect ratio (`width / height`) of the monitor the workspace occupies. Rules are checked in order and the first matching band wins, so a workspace moved to a differently-shaped monitor re-columns automatically. A monitor matching no rule keeps the normal tiling layout.
+
+```yaml
+general:
+  default_columns:
+    # Ultrawide (~21:9 and wider): center flanked by two stacks.
+    - min_aspect_ratio: 2.1
+      spec: "*,C,*"
+      center: 0.5
+    # Standard widescreen (~16:9): center with a single side stack.
+    - min_aspect_ratio: 1.5
+      spec: "C,*"
+      bias: "right"
+    # Anything narrower: normal tiling.
+    - spec: default
+```
+
+**Commands.** Bind these in the `keybindings` section:
+
+| Command | Description |
+| --- | --- |
+| `columns [<spec>] [--center <fraction>] [--bias left\|right]` | Apply a one-shot layout to the focused workspace. Bare `columns` re-asserts the assigned layout; with no assignment it defaults to `*,C,*`. |
+| `assign-columns [<spec>] [--center <fraction>] [--bias left\|right]` | Assign a persistent layout to the focused workspace (equivalent to setting `columns` in the config). |
+| `unassign-columns` | Clear the workspace's assigned layout and return to normal tiling. |
+| `center` | Swap the focused window into the center column. Running it again swaps the previous center back. |
+| `rotate [--ccw]` | Rotate windows through the columns by one slot, preserving the layout shape. `--ccw` rotates counter-clockwise. |
+
+Within a columns layout, `move` in a direction is grid-aware — it shifts the focused window between columns and stacks rather than breaking the layout.
 
 ### Config: Window rules
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Columns turn a workspace into a **centered-focus layout**: the focused window si
 
 A column `spec` is a comma-separated, left-to-right list of columns. Each token is one column:
 
-- `C` — the wide **center** column, holding the focused window. Exactly one `C` is required.
+- `C` — the wide **center** column, holding the focused window. Optional, but at most one: include a `C` for a centered-focus layout, or leave it out (e.g. `*,*`, `2,2`) for plain **equal-width columns** where no window is privileged and `center` is ignored.
 - a **number** (`1`, `2`, `3`, …) — a *fixed* stack holding exactly that many windows.
 - `*` — a *flexible* stack that shares out whatever windows the fixed columns don't take, split evenly across all `*` columns.
 

--- a/packages/wm-common/Cargo.toml
+++ b/packages/wm-common/Cargo.toml
@@ -15,3 +15,6 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 wm-platform = { path = "../wm-platform" }
+
+[dev-dependencies]
+serde_yaml = "0.9"

--- a/packages/wm-common/src/app_command.rs
+++ b/packages/wm-common/src/app_command.rs
@@ -159,6 +159,11 @@ pub enum InvokeCommand {
   Close,
   Focus(InvokeFocusCommand),
   Ignore,
+  Columns(InvokeColumnsCommand),
+  AssignColumns(InvokeColumnsCommand),
+  UnassignColumns,
+  Rotate(InvokeRotateCommand),
+  Center,
   Move(InvokeMoveCommand),
   MoveWorkspace {
     #[clap(long)]
@@ -344,6 +349,82 @@ pub struct InvokeFocusCommand {
 
   #[clap(long)]
   pub recent_workspace: bool,
+}
+
+#[derive(
+  Clone, Debug, Default, Deserialize, PartialEq, Serialize, ValueEnum,
+)]
+#[clap(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum ColumnBias {
+  #[default]
+  Left,
+  Right,
+}
+
+#[derive(Args, Clone, Debug, PartialEq, Serialize)]
+pub struct InvokeColumnsCommand {
+  /// Comma-separated columns, left-to-right. Each token is a column: a
+  /// number is that many windows stacked, `*` claims an even share of
+  /// the leftover windows, and `C` is the wide center (focused window;
+  /// exactly one). E.g. `*,C,*`, `C,*`, or `2,1,C,3`. Must be
+  /// space-free.
+  ///
+  /// Omitted (bare `columns`), it re-asserts the workspace's assigned
+  /// columns; otherwise it defaults to `*,C,*`.
+  pub spec: Option<String>,
+
+  /// Center column width as a fraction of the workspace (0.1..=0.9). The
+  /// remaining width is split equally across the other columns. Defaults
+  /// to `0.6`.
+  #[clap(long, allow_hyphen_values = true)]
+  pub center: Option<f32>,
+
+  /// Which side wins the odd leftover window when `*` columns can't
+  /// divide evenly (e.g. `*,C,*` with one window to place). Defaults to
+  /// `left`.
+  #[clap(long, value_enum)]
+  pub bias: Option<ColumnBias>,
+}
+
+impl InvokeColumnsCommand {
+  /// Default column spec when none is supplied.
+  pub const DEFAULT_SPEC: &'static str = "*,C,*";
+
+  /// Default center-column width fraction when none is supplied.
+  pub const DEFAULT_CENTER: f32 = 0.6;
+
+  /// Whether no column parameters were supplied, i.e. a bare `columns`.
+  #[must_use]
+  pub fn is_unset(&self) -> bool {
+    self.spec.is_none() && self.center.is_none() && self.bias.is_none()
+  }
+
+  /// The supplied column spec, or the default `*,C,*`.
+  #[must_use]
+  pub fn spec_or_default(&self) -> &str {
+    self.spec.as_deref().unwrap_or(Self::DEFAULT_SPEC)
+  }
+
+  /// The supplied center width, or the default `0.6`.
+  #[must_use]
+  pub fn center_or_default(&self) -> f32 {
+    self.center.unwrap_or(Self::DEFAULT_CENTER)
+  }
+
+  /// The supplied bias, or the default (`left`).
+  #[must_use]
+  pub fn bias_or_default(&self) -> ColumnBias {
+    self.bias.clone().unwrap_or_default()
+  }
+}
+
+#[derive(Args, Clone, Debug, PartialEq, Serialize)]
+pub struct InvokeRotateCommand {
+  /// Rotate counter-clockwise instead of clockwise. The layout is
+  /// preserved; only the window in each slot shifts by one.
+  #[clap(long)]
+  pub ccw: bool,
 }
 
 #[derive(Args, Clone, Debug, PartialEq, Serialize)]

--- a/packages/wm-common/src/app_command.rs
+++ b/packages/wm-common/src/app_command.rs
@@ -366,9 +366,10 @@ pub enum ColumnBias {
 pub struct InvokeColumnsCommand {
   /// Comma-separated columns, left-to-right. Each token is a column: a
   /// number is that many windows stacked, `*` claims an even share of
-  /// the leftover windows, and `C` is the wide center (focused window;
-  /// exactly one). E.g. `*,C,*`, `C,*`, or `2,1,C,3`. Must be
-  /// space-free.
+  /// the leftover windows, and `C` is the wide center (focused window; at
+  /// most one). E.g. `*,C,*`, `C,*`, or `2,1,C,3`. `C` is optional: a
+  /// spec without one (e.g. `*,*` or `2,2`) makes plain equal-width
+  /// columns with no wide center. Must be space-free.
   ///
   /// Omitted (bare `columns`), it re-asserts the workspace's assigned
   /// columns; otherwise it defaults to `*,C,*`.

--- a/packages/wm-common/src/parsed_config.rs
+++ b/packages/wm-common/src/parsed_config.rs
@@ -1,10 +1,10 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use wm_platform::{
   Color, CornerStyle, Key, Keybinding, LengthValue, OpacityValue,
   RectDelta,
 };
 
-use crate::app_command::InvokeCommand;
+use crate::app_command::{ColumnBias, InvokeCommand};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default, rename_all(serialize = "camelCase"))]
@@ -96,6 +96,12 @@ pub struct GeneralConfig {
 
   /// Affects which windows get shown in the native Windows taskbar.
   pub show_all_in_taskbar: bool,
+
+  /// A default column layout applied to any workspace that has no
+  /// `columns:` of its own, chosen from the shape of the monitor the
+  /// workspace currently occupies. See [`DefaultColumns`].
+  #[serde(default)]
+  pub default_columns: Option<DefaultColumns>,
 }
 
 impl Default for GeneralConfig {
@@ -118,6 +124,7 @@ impl Default for GeneralConfig {
         }
       },
       show_all_in_taskbar: false,
+      default_columns: None,
     }
   }
 }
@@ -385,6 +392,208 @@ pub struct WorkspaceConfig {
 
   #[serde(default = "default_bool::<false>")]
   pub keep_alive: bool,
+
+  /// A column layout assigned to this workspace, applied whenever the
+  /// workspace is focused. Accepts either a bare spec string
+  /// (`columns: "*,C,*"`) or a full object (`columns: { spec, center,
+  /// bias }`).
+  #[serde(default)]
+  pub columns: Option<ColumnLayout>,
+}
+
+/// A `columns` layout assigned to a workspace. Applied on focus and
+/// reapplied on every switch back to the workspace.
+///
+/// Deserializes from either a bare spec string (`"*,C,*"`) or a full
+/// object (`{ spec: "*,C,*", center: 0.6, bias: left }`).
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct ColumnLayout {
+  pub spec: String,
+  pub center: f32,
+  pub bias: ColumnBias,
+}
+
+/// Helper function for the default center width of a column layout.
+fn default_columns_center() -> f32 {
+  0.6
+}
+
+impl<'de> Deserialize<'de> for ColumnLayout {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Raw {
+      Spec(String),
+      Full {
+        spec: String,
+        #[serde(default = "default_columns_center")]
+        center: f32,
+        #[serde(default)]
+        bias: ColumnBias,
+      },
+    }
+
+    Ok(match Raw::deserialize(deserializer)? {
+      Raw::Spec(spec) => ColumnLayout {
+        spec,
+        center: default_columns_center(),
+        bias: ColumnBias::default(),
+      },
+      Raw::Full { spec, center, bias } => {
+        ColumnLayout { spec, center, bias }
+      }
+    })
+  }
+}
+
+/// A monitor-shape-gated default column layout, applied to any workspace
+/// that has no `columns:` of its own. The layout is the first rule whose
+/// aspect-ratio band contains the workspace's current monitor's aspect
+/// ratio; a workspace matching no rule keeps the default tiling.
+///
+/// Deserializes from a bare spec string (`"*,C,*"`), a single rule object,
+/// or an ordered list of rule objects (first match wins).
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct DefaultColumns {
+  pub rules: Vec<DefaultColumnsRule>,
+}
+
+/// One aspect-ratio-gated rule within a [`DefaultColumns`].
+///
+/// `min_aspect_ratio` (inclusive) and `max_aspect_ratio` (exclusive) bound
+/// the monitor aspect ratios (`width / height`, so landscape > 1) the rule
+/// matches; either or both may be omitted for an open-ended or catch-all
+/// rule. `columns` is the layout applied when the rule matches, or `None`
+/// to explicitly keep default tiling for the band (spec `default`/`none`).
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct DefaultColumnsRule {
+  pub min_aspect_ratio: Option<f32>,
+  pub max_aspect_ratio: Option<f32>,
+  pub columns: Option<ColumnLayout>,
+}
+
+impl DefaultColumns {
+  /// The columns to apply on a monitor of the given `aspect_ratio`
+  /// (`width / height`): the first rule whose band contains it, resolved
+  /// to its columns.
+  ///
+  /// Returns `None` when no rule matches, or the matched rule is an
+  /// explicit `default`/`none` — both meaning "keep default tiling". A
+  /// rule matches when `aspect_ratio` is `>= min_aspect_ratio` (when set)
+  /// and `< max_aspect_ratio` (when set).
+  #[must_use]
+  pub fn columns_for(&self, aspect_ratio: f32) -> Option<ColumnLayout> {
+    self
+      .rules
+      .iter()
+      .find(|rule| {
+        rule.min_aspect_ratio.is_none_or(|min| aspect_ratio >= min)
+          && rule.max_aspect_ratio.is_none_or(|max| aspect_ratio < max)
+      })
+      .and_then(|rule| rule.columns.clone())
+  }
+}
+
+impl<'de> Deserialize<'de> for DefaultColumns {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    /// A rule as written in config, with the spec/center/bias flattened
+    /// alongside the aspect-ratio bounds.
+    #[derive(Deserialize)]
+    struct RawRule {
+      #[serde(default)]
+      min_aspect_ratio: Option<f32>,
+      #[serde(default)]
+      max_aspect_ratio: Option<f32>,
+      spec: String,
+      #[serde(default = "default_columns_center")]
+      center: f32,
+      #[serde(default)]
+      bias: ColumnBias,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Raw {
+      Spec(String),
+      Rules(Vec<RawRule>),
+      Single(RawRule),
+    }
+
+    /// Converts a raw rule into a validated [`DefaultColumnsRule`],
+    /// mapping the `default`/`none` spec sentinel to no columns.
+    fn build_rule<E: serde::de::Error>(
+      raw: RawRule,
+    ) -> Result<DefaultColumnsRule, E> {
+      if let (Some(min), Some(max)) =
+        (raw.min_aspect_ratio, raw.max_aspect_ratio)
+      {
+        if min >= max {
+          return Err(E::custom(format!(
+            "`min_aspect_ratio` ({min}) must be less than \
+             `max_aspect_ratio` ({max})."
+          )));
+        }
+      }
+
+      for bound in [raw.min_aspect_ratio, raw.max_aspect_ratio]
+        .into_iter()
+        .flatten()
+      {
+        if bound <= 0.0 {
+          return Err(E::custom(
+            "Aspect-ratio bounds must be greater than 0.",
+          ));
+        }
+      }
+
+      let columns = if matches!(
+        raw.spec.to_lowercase().as_str(),
+        "default" | "none"
+      ) {
+        None
+      } else {
+        Some(ColumnLayout {
+          spec: raw.spec,
+          center: raw.center,
+          bias: raw.bias,
+        })
+      };
+
+      Ok(DefaultColumnsRule {
+        min_aspect_ratio: raw.min_aspect_ratio,
+        max_aspect_ratio: raw.max_aspect_ratio,
+        columns,
+      })
+    }
+
+    let raw_rules = match Raw::deserialize(deserializer)? {
+      Raw::Spec(spec) => vec![RawRule {
+        min_aspect_ratio: None,
+        max_aspect_ratio: None,
+        spec,
+        center: default_columns_center(),
+        bias: ColumnBias::default(),
+      }],
+      Raw::Single(rule) => vec![rule],
+      Raw::Rules(rules) => rules,
+    };
+
+    let rules = raw_rules
+      .into_iter()
+      .map(build_rule)
+      .collect::<Result<Vec<_>, D::Error>>()?;
+
+    Ok(DefaultColumns { rules })
+  }
 }
 
 /// Helper function for setting a default value for a boolean field.
@@ -470,5 +679,125 @@ where
   #[cfg(not(target_os = "macos"))]
   {
     Ok(method)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{ColumnBias, DefaultColumns};
+
+  fn parse(yaml: &str) -> DefaultColumns {
+    serde_yaml::from_str(yaml).expect("valid default_columns")
+  }
+
+  #[test]
+  fn deserializes_bare_spec_string() {
+    let parsed = parse(r#""*,C,*""#);
+
+    assert_eq!(parsed.rules.len(), 1);
+    let rule = &parsed.rules[0];
+    assert_eq!(rule.min_aspect_ratio, None);
+    assert_eq!(rule.max_aspect_ratio, None);
+    let assignment = rule.columns.as_ref().expect("columns");
+    assert_eq!(assignment.spec, "*,C,*");
+    assert_eq!(assignment.bias, ColumnBias::Left);
+  }
+
+  #[test]
+  fn deserializes_single_object() {
+    let parsed = parse("{ spec: \"C,*\", center: 0.5, bias: right }");
+
+    assert_eq!(parsed.rules.len(), 1);
+    let assignment = parsed.rules[0].columns.as_ref().expect("columns");
+    assert_eq!(assignment.spec, "C,*");
+    assert!((assignment.center - 0.5).abs() < f32::EPSILON);
+    assert_eq!(assignment.bias, ColumnBias::Right);
+  }
+
+  #[test]
+  fn deserializes_rule_list_and_default_sentinel() {
+    let parsed = parse(
+      "
+      - min_aspect_ratio: 2.0
+        spec: \"*,C,*\"
+      - min_aspect_ratio: 1.4
+        spec: default
+      - spec: \"C\"
+      ",
+    );
+
+    assert_eq!(parsed.rules.len(), 3);
+    assert_eq!(parsed.rules[0].min_aspect_ratio, Some(2.0));
+    assert!(parsed.rules[0].columns.is_some());
+    // `default` is an explicit "keep default tiling" band.
+    assert!(parsed.rules[1].columns.is_none());
+    assert!(parsed.rules[2].columns.is_some());
+  }
+
+  #[test]
+  fn rejects_inverted_bounds() {
+    let result: Result<DefaultColumns, _> = serde_yaml::from_str(
+      "
+      - min_aspect_ratio: 2.0
+        max_aspect_ratio: 1.0
+        spec: \"C\"
+      ",
+    );
+
+    assert!(result.is_err());
+  }
+
+  #[test]
+  fn columns_for_picks_first_matching_band() {
+    let parsed = parse(
+      "
+      - min_aspect_ratio: 2.0
+        spec: ultrawide
+      - min_aspect_ratio: 1.4
+        spec: wide
+      ",
+    );
+
+    // Ultrawide → first rule.
+    assert_eq!(
+      parsed.columns_for(2.37).map(|s| s.spec),
+      Some("ultrawide".to_string())
+    );
+    // ~16:9 → second rule (first doesn't match).
+    assert_eq!(
+      parsed.columns_for(1.78).map(|s| s.spec),
+      Some("wide".to_string())
+    );
+    // 4:3 → no rule matches → default tiling.
+    assert_eq!(parsed.columns_for(1.33).map(|s| s.spec), None);
+  }
+
+  #[test]
+  fn columns_for_bounds_are_min_inclusive_max_exclusive() {
+    let parsed = parse(
+      "
+      - min_aspect_ratio: 1.5
+        max_aspect_ratio: 2.0
+        spec: band
+      ",
+    );
+
+    assert!(parsed.columns_for(1.5).is_some(), "min is inclusive");
+    assert!(parsed.columns_for(1.99).is_some(), "inside band");
+    assert!(parsed.columns_for(2.0).is_none(), "max is exclusive");
+    assert!(parsed.columns_for(1.49).is_none(), "below band");
+  }
+
+  #[test]
+  fn columns_for_returns_none_on_matched_default_band() {
+    let parsed = parse(
+      "
+      - min_aspect_ratio: 1.4
+        spec: none
+      ",
+    );
+
+    // The band matches, but resolves to default tiling.
+    assert!(parsed.columns_for(1.78).is_none());
   }
 }

--- a/packages/wm/src/commands/general/reload_config.rs
+++ b/packages/wm/src/commands/general/reload_config.rs
@@ -7,7 +7,10 @@ use wm_common::{WindowRuleEvent, WmEvent};
 use wm_platform::NativeWindowWindowsExt;
 
 use crate::{
-  commands::{window::run_window_rules, workspace::sort_workspaces},
+  commands::{
+    window::run_window_rules,
+    workspace::{reapply_assigned_columns, sort_workspaces},
+  },
   traits::{CommonGetters, TilingSizeGetters, WindowGetters},
   user_config::UserConfig,
   wm::WindowManager,
@@ -134,6 +137,14 @@ fn update_workspace_configs(
         }
       }
     }
+  }
+
+  // Reapply assigned columns now configs are refreshed, so editing a
+  // workspace's `columns` and reloading takes effect immediately. The
+  // configs were just replaced from the file, so this also discards any
+  // runtime manual center resize. A no-op for workspaces without columns.
+  for workspace in state.workspaces() {
+    reapply_assigned_columns(&workspace, None, state, config)?;
   }
 
   Ok(())

--- a/packages/wm/src/commands/window/manage_window.rs
+++ b/packages/wm/src/commands/window/manage_window.rs
@@ -7,6 +7,7 @@ use crate::{
   commands::{
     container::{attach_container, set_focused_descendant},
     window::run_window_rules,
+    workspace::reapply_assigned_columns,
   },
   models::{
     Container, Monitor, NativeWindowProperties, NonTilingWindow,
@@ -71,14 +72,22 @@ pub fn manage_window(
       window.workspace().context("No workspace.")?,
     );
 
+    let is_tiling = window.state() == WindowState::Tiling;
+    let workspace = window.workspace().context("No workspace.")?;
+
     // Sibling containers need to be redrawn if the window is tiling.
-    state.pending_sync.queue_container_to_redraw(
-      if window.state() == WindowState::Tiling {
-        window.parent().context("No parent.")?
-      } else {
-        window.into()
-      },
-    );
+    state.pending_sync.queue_container_to_redraw(if is_tiling {
+      window.parent().context("No parent.")?
+    } else {
+      window.into()
+    });
+
+    // Reapply the workspace's columns (if any) so the new tiling window
+    // slots into the layout. This also covers startup, since every
+    // existing window is managed through here.
+    if is_tiling {
+      reapply_assigned_columns(&workspace, None, state, config)?;
+    }
   }
 
   Ok(())

--- a/packages/wm/src/commands/window/manage_window.rs
+++ b/packages/wm/src/commands/window/manage_window.rs
@@ -79,14 +79,23 @@ pub fn manage_window(
     state.pending_sync.queue_container_to_redraw(if is_tiling {
       window.parent().context("No parent.")?
     } else {
-      window.into()
+      window.clone().into()
     });
 
     // Reapply the workspace's columns (if any) so the new tiling window
     // slots into the layout. This also covers startup, since every
     // existing window is managed through here.
-    if is_tiling {
-      reapply_assigned_columns(&workspace, None, state, config)?;
+    if is_tiling
+      && reapply_assigned_columns(&workspace, None, state, config)?
+    {
+      // The reapply rebuilds the workspace subtree, which can shuffle the
+      // focus order and leave a displaced window carrying a stale focused
+      // border (the default effect update only refreshes the previously
+      // focused window). Re-assert focus on the new window and reset every
+      // window's effect so exactly one — the new center — shows as
+      // focused.
+      set_focused_descendant(&window.clone().into(), None);
+      state.pending_sync.queue_all_effects_update();
     }
   }
 

--- a/packages/wm/src/commands/window/move_window_in_direction.rs
+++ b/packages/wm/src/commands/window/move_window_in_direction.rs
@@ -3,10 +3,13 @@ use wm_common::{TilingDirection, WindowState};
 use wm_platform::{Direction, Rect};
 
 use crate::{
-  commands::container::{
-    flatten_child_split_containers, flatten_split_container,
-    move_container_within_tree, resize_tiling_container,
-    set_focused_descendant, wrap_in_split_container,
+  commands::{
+    container::{
+      flatten_child_split_containers, flatten_split_container,
+      move_container_within_tree, resize_tiling_container,
+      set_focused_descendant, wrap_in_split_container,
+    },
+    workspace::{reapply_columns_after_move, workspace_center_window_id},
   },
   models::{
     DirectionContainer, Monitor, NonTilingWindow, SplitContainer,
@@ -41,6 +44,7 @@ pub fn move_window_in_direction(
           &non_tiling_window.into(),
           direction,
           state,
+          config,
         ),
         _ => Ok(()),
       }
@@ -94,6 +98,7 @@ fn move_tiling_window(
       &window_to_move.into(),
       direction,
       state,
+      config,
     );
   }
 
@@ -206,10 +211,14 @@ fn move_to_sibling_container(
   Ok(())
 }
 
-fn move_to_workspace_in_direction(
+/// Moves a window to the displayed workspace of the monitor in the given
+/// direction, re-tidying both workspaces' columns. A no-op when there is
+/// no monitor in that direction.
+pub(crate) fn move_to_workspace_in_direction(
   window_to_move: &WindowContainer,
   direction: &Direction,
   state: &mut WmState,
+  config: &UserConfig,
 ) -> anyhow::Result<()> {
   let parent = window_to_move.parent().context("No parent.")?;
   let workspace = window_to_move.workspace().context("No workspace.")?;
@@ -244,6 +253,13 @@ fn move_to_workspace_in_direction(
       _ => target_workspace.child_count(),
     };
 
+    // Capture columns state before the move: the source's current center
+    // (so its layout re-tidies without shifting center) and the moving
+    // window (so it becomes the target's center on arrival).
+    let is_tiling = window_to_move.is_tiling_window();
+    let moved_window_id = window_to_move.id();
+    let source_center = workspace_center_window_id(&workspace);
+
     // Focus should be reassigned within the original workspace after the
     // window is moved out. For example, if the focus order is 1. tiling
     // window and 2. fullscreen window, then we'd want to retain focus on a
@@ -270,7 +286,19 @@ fn move_to_workspace_in_direction(
       .queue_containers_to_redraw(target_workspace.tiling_children())
       .queue_containers_to_redraw(parent.tiling_children())
       .queue_cursor_jump()
-      .queue_workspace_to_reorder(target_workspace);
+      .queue_workspace_to_reorder(target_workspace.clone());
+
+    // Reapply assigned columns now the window has changed workspaces.
+    if is_tiling {
+      reapply_columns_after_move(
+        &workspace,
+        source_center,
+        &target_workspace,
+        moved_window_id,
+        state,
+        config,
+      )?;
+    }
   }
 
   Ok(())

--- a/packages/wm/src/commands/window/move_window_to_workspace.rs
+++ b/packages/wm/src/commands/window/move_window_to_workspace.rs
@@ -5,7 +5,10 @@ use wm_common::WindowState;
 use crate::{
   commands::{
     container::{move_container_within_tree, set_focused_descendant},
-    workspace::activate_workspace,
+    workspace::{
+      activate_workspace, reapply_columns_after_move,
+      workspace_center_window_id,
+    },
   },
   models::{WindowContainer, WorkspaceTarget},
   traits::{CommonGetters, PositionGetters, WindowGetters},
@@ -13,6 +16,7 @@ use crate::{
   wm_state::WmState,
 };
 
+#[allow(clippy::too_many_lines)]
 pub fn move_window_to_workspace(
   window: WindowContainer,
   target: WorkspaceTarget,
@@ -72,6 +76,13 @@ pub fn move_window_to_workspace(
     if let WindowContainer::NonTilingWindow(window) = &window {
       window.set_insertion_target(None);
     }
+
+    // Capture columns state before the move: the source's current center
+    // (so its layout re-tidies without shifting center) and the moving
+    // window (so it becomes the target's center on arrival).
+    let is_tiling = window.is_tiling_window();
+    let moved_window_id = window.id();
+    let source_center = workspace_center_window_id(&current_workspace);
 
     // Focus target is `None` if the window is not focused.
     let focus_target = state.focus_target_after_removal(&window);
@@ -141,7 +152,19 @@ pub fn move_window_to_workspace(
 
     state
       .pending_sync
-      .queue_workspace_to_reorder(target_workspace);
+      .queue_workspace_to_reorder(target_workspace.clone());
+
+    // Reapply assigned columns now the window has changed workspaces.
+    if is_tiling {
+      reapply_columns_after_move(
+        &current_workspace,
+        source_center,
+        &target_workspace,
+        moved_window_id,
+        state,
+        config,
+      )?;
+    }
   }
 
   Ok(())

--- a/packages/wm/src/commands/window/set_window_size.rs
+++ b/packages/wm/src/commands/window/set_window_size.rs
@@ -3,7 +3,9 @@ use wm_common::WindowState;
 use wm_platform::{LengthValue, Rect};
 
 use crate::{
-  commands::container::resize_tiling_container,
+  commands::{
+    container::resize_tiling_container, workspace::store_center_width,
+  },
   models::{NonTilingWindow, TilingWindow, WindowContainer},
   traits::{
     CommonGetters, PositionGetters, TilingSizeGetters, WindowGetters,
@@ -24,6 +26,14 @@ pub fn set_window_size(
   match window {
     WindowContainer::TilingWindow(window) => {
       set_tiling_window_size(&window, target_width, target_height, state)?;
+
+      // A tiling resize is user intent, so record the resulting center
+      // width into the workspace's columns (if assigned), making it
+      // persist across later reapplies until config reload or
+      // restart.
+      if let Some(workspace) = window.workspace() {
+        store_center_width(&workspace);
+      }
     }
     WindowContainer::NonTilingWindow(window) => {
       if matches!(window.state(), WindowState::Floating(_)) {

--- a/packages/wm/src/commands/workspace/columns/grid.rs
+++ b/packages/wm/src/commands/workspace/columns/grid.rs
@@ -1,0 +1,200 @@
+//! The `ColumnGrid`: the single bridge between the window container tree
+//! and the flat column grid the column commands manipulate.
+
+use uuid::Uuid;
+use wm_common::TilingDirection;
+
+use crate::{
+  commands::container::{
+    move_container_within_tree, wrap_in_split_container,
+  },
+  models::{
+    Container, SplitContainer, TilingContainer, TilingWindow, Workspace,
+  },
+  traits::{CommonGetters, TilingDirectionGetters, TilingSizeGetters},
+  user_config::UserConfig,
+  wm_state::WmState,
+};
+
+/// A workspace's tiling windows viewed as a left-to-right sequence of
+/// columns, each a top-to-bottom stack of windows, paired with each
+/// column's current width fraction.
+///
+/// This is the one place that knows how the declarative columns map onto
+/// the container tree: [`ColumnGrid::read`] lifts the tree into the grid
+/// and [`ColumnGrid::render`] rebuilds the tree from it. The commands
+/// operate purely on the grid in between, and the layout's center is
+/// defined here as the widest column (see [`ColumnGrid::center_index`]).
+pub(super) struct ColumnGrid {
+  /// Columns left-to-right, each a top-to-bottom stack of windows.
+  pub columns: Vec<Vec<TilingWindow>>,
+
+  /// Width fraction of each column, index-aligned with `columns`.
+  pub widths: Vec<f32>,
+}
+
+impl ColumnGrid {
+  /// Reads the workspace's top-level columns — each a top-to-bottom list
+  /// of windows — paired with their current widths.
+  pub fn read(workspace: &Workspace) -> Self {
+    let mut columns: Vec<Vec<TilingWindow>> = Vec::new();
+    let mut widths: Vec<f32> = Vec::new();
+
+    for child in workspace.tiling_children() {
+      match child {
+        TilingContainer::TilingWindow(window) => {
+          widths.push(window.tiling_size());
+          columns.push(vec![window]);
+        }
+        TilingContainer::Split(split) => {
+          widths.push(split.tiling_size());
+          columns.push(
+            split
+              .descendants()
+              .filter_map(|container| match container {
+                Container::TilingWindow(window) => Some(window),
+                _ => None,
+              })
+              .collect(),
+          );
+        }
+      }
+    }
+
+    Self { columns, widths }
+  }
+
+  /// Total number of tiling windows across all columns.
+  pub fn window_count(&self) -> usize {
+    self.columns.iter().map(Vec::len).sum()
+  }
+
+  /// Index of the widest column, treated as the layout's center.
+  pub fn center_index(&self) -> usize {
+    (0..self.widths.len())
+      .max_by(|&a, &b| self.widths[a].total_cmp(&self.widths[b]))
+      .unwrap_or(0)
+  }
+
+  /// Id of the window in the center column's top slot, if the workspace
+  /// has any tiling windows.
+  pub fn center_window_id(&self) -> Option<Uuid> {
+    self
+      .columns
+      .get(self.center_index())
+      .and_then(|col| col.first())
+      .map(CommonGetters::id)
+  }
+
+  /// Current width fraction of the center column, if present.
+  pub fn center_width(&self) -> Option<f32> {
+    self.widths.get(self.center_index()).copied()
+  }
+
+  /// `(column, row)` position of the window with `id`, if present.
+  pub fn find(&self, id: Uuid) -> Option<(usize, usize)> {
+    self.columns.iter().enumerate().find_map(|(col, windows)| {
+      windows
+        .iter()
+        .position(|window| window.id() == id)
+        .map(|row| (col, row))
+    })
+  }
+
+  /// Rebuilds `workspace` into these columns (left-to-right), sized to
+  /// their widths. Empty columns are dropped and widths renormalised.
+  ///
+  /// Uses only the existing tree primitives — `move_container_within_tree`
+  /// to gather windows and `wrap_in_split_container` to form columns — so
+  /// windows stay tiled and the workspace is redrawn once at the end (no
+  /// flicker).
+  #[allow(clippy::cast_precision_loss)]
+  pub fn render(
+    self,
+    workspace: &Workspace,
+    state: &mut WmState,
+    config: &UserConfig,
+  ) -> anyhow::Result<()> {
+    // Drop empty columns, pairing each surviving column with its width.
+    let mut cols: Vec<Vec<TilingWindow>> = Vec::new();
+    let mut fracs: Vec<f32> = Vec::new();
+    for (column, width) in self.columns.into_iter().zip(self.widths) {
+      if !column.is_empty() {
+        cols.push(column);
+        fracs.push(width);
+      }
+    }
+
+    if cols.is_empty() {
+      return Ok(());
+    }
+
+    // Normalise so column fractions sum to 1.
+    let total = fracs.iter().sum::<f32>().max(f32::EPSILON);
+    for frac in &mut fracs {
+      *frac /= total;
+    }
+
+    // Columns sit side-by-side, so the workspace must tile horizontally.
+    workspace.set_tiling_direction(TilingDirection::Horizontal);
+    let workspace_container: Container = workspace.clone().into();
+
+    // Phase 1: pull every window up to the workspace in the final flat
+    // order (columns left-to-right, windows top-to-bottom). Moving windows
+    // out of their old split containers flattens those splits away.
+    let flat = cols.iter().flatten().cloned().collect::<Vec<_>>();
+    for (index, window) in flat.iter().enumerate() {
+      let container: Container = window.clone().into();
+      move_container_within_tree(
+        &container,
+        &workspace_container,
+        index,
+        state,
+      )?;
+    }
+
+    // Phase 2: wrap each multi-window column into a vertical split. A
+    // single window column already sits directly under the workspace.
+    let mut column_entities: Vec<Container> = Vec::new();
+    for column in &cols {
+      if column.len() == 1 {
+        column_entities.push(column[0].clone().into());
+        continue;
+      }
+
+      let split = SplitContainer::new(
+        TilingDirection::Vertical,
+        config.value.gaps.clone(),
+      );
+
+      let children = column
+        .iter()
+        .map(|window| window.clone().into())
+        .collect::<Vec<TilingContainer>>();
+
+      wrap_in_split_container(&split, &workspace_container, &children)?;
+
+      // Even split between the column's rows.
+      let row_size = 1.0 / column.len() as f32;
+      for window in column {
+        window.set_tiling_size(row_size);
+      }
+
+      column_entities.push(split.into());
+    }
+
+    // Phase 3: set each column's width.
+    for (entity, frac) in column_entities.iter().zip(&fracs) {
+      if let Ok(tiling) = entity.as_tiling_container() {
+        tiling.set_tiling_size(*frac);
+      }
+    }
+
+    // One atomic redraw of the whole workspace.
+    state
+      .pending_sync
+      .queue_container_to_redraw(workspace_container);
+
+    Ok(())
+  }
+}

--- a/packages/wm/src/commands/workspace/columns/grid.rs
+++ b/packages/wm/src/commands/workspace/columns/grid.rs
@@ -76,6 +76,21 @@ impl ColumnGrid {
       .unwrap_or(0)
   }
 
+  /// Whether the grid has a single strictly-widest column — the wide
+  /// center. Equal-width columns (a `C`-less layout) have no center, so
+  /// commands that act on the center (e.g. `center`) become no-ops.
+  pub fn has_center(&self) -> bool {
+    let Some(max) = self.widths.iter().copied().reduce(f32::max) else {
+      return false;
+    };
+    self
+      .widths
+      .iter()
+      .filter(|&&w| (max - w).abs() < 1e-4)
+      .count()
+      == 1
+  }
+
   /// Id of the window in the center column's top slot, if the workspace
   /// has any tiling windows.
   pub fn center_window_id(&self) -> Option<Uuid> {

--- a/packages/wm/src/commands/workspace/columns/mod.rs
+++ b/packages/wm/src/commands/workspace/columns/mod.rs
@@ -1,0 +1,1254 @@
+//! The `columns` feature: declarative, centered-focus column layouts.
+//!
+//! Layout is split across three concerns:
+//! - [`spec`]: pure parsing of a column `spec` and distribution of windows
+//!   into columns (no tree dependency, unit-tested).
+//! - [`grid`]: the [`ColumnGrid`] bridge that lifts the container tree
+//!   into a flat grid and renders it back.
+//! - this module: the commands and config resolution that drive the two.
+
+mod grid;
+mod spec;
+
+use anyhow::Context;
+use uuid::Uuid;
+use wm_common::{ColumnBias, ColumnLayout};
+use wm_platform::Direction;
+
+use self::{
+  grid::ColumnGrid,
+  spec::{column_widths, distribute_columns, parse_columns_spec},
+};
+use crate::{
+  commands::{
+    container::focus_container_by_id,
+    window::move_to_workspace_in_direction,
+  },
+  models::{Container, TilingWindow, WindowContainer, Workspace},
+  traits::{CommonGetters, PositionGetters},
+  user_config::UserConfig,
+  wm_state::WmState,
+};
+
+/// Arranges the focused workspace into a centered-focus layout described
+/// by a comma-separated column `spec`, laid out left-to-right. Each token
+/// is one column: a number is that many windows stacked, `*` claims an
+/// even share of the leftover windows, and `C` is the wide center (the
+/// focused window; exactly one). E.g. `*,C,*` is a center flanked by two
+/// even stacks, `C,*` drops the left band for a narrow monitor, and
+/// `2,1,C,3` is fully explicit.
+///
+/// The center window fills the `C` column at `center` width (a fraction of
+/// the workspace, clamped to `0.1..=0.9`); the remaining columns split the
+/// rest of the width evenly. Windows are assigned in on-screen order, left
+/// to right. When `*` columns can't split the leftovers evenly, `bias`
+/// decides which end claims the odd window(s). Any window still unplaced
+/// (fixed counts under-specify the total and there is no `*`) is appended
+/// to the last non-center column. Columns that end up empty are dropped
+/// and the widths renormalise, so a wide spec still degrades cleanly on a
+/// small monitor.
+///
+/// The `C` column takes `preferred_center` when set and that window is
+/// still present, otherwise the focused window, otherwise the middle
+/// window by position. Passing the current center as `preferred_center`
+/// keeps the layout stable across reapplies that aren't meant to move the
+/// center (e.g. after a side window closes).
+pub fn apply_columns(
+  workspace: &Workspace,
+  spec: &str,
+  center: f32,
+  bias: &ColumnBias,
+  preferred_center: Option<Uuid>,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<()> {
+  let kinds = parse_columns_spec(spec)?;
+
+  let mut windows = workspace
+    .descendants()
+    .filter_map(|container| match container {
+      Container::TilingWindow(window) => Some(window),
+      _ => None,
+    })
+    .collect::<Vec<_>>();
+
+  if windows.len() < 2 {
+    return Ok(());
+  }
+
+  windows.sort_by_key(|window| {
+    window.to_rect().map_or((0, 0), |rect| (rect.x(), rect.y()))
+  });
+
+  // Center = the preferred center window if it's still present, else the
+  // focused tiling window, else the middle one by position.
+  let focused_id = focused_window_id(workspace);
+
+  let center_index = preferred_center
+    .and_then(|id| windows.iter().position(|window| window.id() == id))
+    .or_else(|| {
+      focused_id
+        .and_then(|id| windows.iter().position(|window| window.id() == id))
+    })
+    .unwrap_or(windows.len() / 2);
+
+  let center_window = windows[center_index].clone();
+
+  // A different window is taking the center, so the one it phases out
+  // becomes the `center` toggle's swap-back target.
+  remember_outgoing_center(workspace, center_window.id(), state);
+
+  let rest = windows
+    .iter()
+    .enumerate()
+    .filter(|(index, _)| *index != center_index)
+    .map(|(_, window)| window.clone())
+    .collect::<Vec<_>>();
+
+  let columns = distribute_columns(&kinds, center_window, rest, bias);
+  let widths = column_widths(&kinds, center.clamp(0.1, 0.9));
+
+  ColumnGrid { columns, widths }.render(workspace, state, config)
+}
+
+/// Assigns a column layout to the workspace and applies it immediately.
+/// The assignment is stored on the workspace and reapplied whenever the
+/// workspace is focused (see `focus_workspace`), until it is unassigned or
+/// the config is reloaded. Runtime assignments are ephemeral; edit
+/// `config.yaml` to persist.
+pub fn assign_columns(
+  workspace: &Workspace,
+  spec: &str,
+  center: f32,
+  bias: &ColumnBias,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<()> {
+  let mut workspace_config = workspace.config();
+  workspace_config.columns = Some(ColumnLayout {
+    spec: spec.to_string(),
+    center,
+    bias: bias.clone(),
+  });
+  workspace.set_config(workspace_config);
+
+  apply_columns(workspace, spec, center, bias, None, state, config)
+}
+
+/// Clears any column layout assigned to the workspace, so switching to it
+/// no longer reapplies a layout. The current arrangement is left
+/// untouched.
+pub fn unassign_columns(workspace: &Workspace) {
+  let mut workspace_config = workspace.config();
+  workspace_config.columns = None;
+  workspace.set_config(workspace_config);
+}
+
+/// Resolves the columns a workspace should currently use: its own assigned
+/// `columns` if set, otherwise the first `general.default_columns` rule
+/// whose aspect-ratio band contains the workspace's current monitor's
+/// aspect ratio (`width / height`).
+///
+/// Returns `None` when the workspace has no assignment and matches no
+/// default rule (or matches an explicit `default`/`none` rule), in which
+/// case the workspace keeps the default tiling. Re-resolved on every
+/// reapply, so a workspace moved to a differently-shaped monitor picks up
+/// that monitor's default.
+pub fn effective_columns(
+  workspace: &Workspace,
+  config: &UserConfig,
+) -> anyhow::Result<Option<ColumnLayout>> {
+  if let Some(columns) = workspace.config().columns {
+    return Ok(Some(columns));
+  }
+
+  let Some(default_columns) = &config.value.general.default_columns else {
+    return Ok(None);
+  };
+
+  let monitor_rect =
+    workspace.monitor().context("No monitor.")?.to_rect()?;
+  #[allow(clippy::cast_precision_loss)]
+  let aspect_ratio =
+    monitor_rect.width() as f32 / monitor_rect.height() as f32;
+
+  Ok(default_columns.columns_for(aspect_ratio))
+}
+
+/// Reapplies the workspace's effective columns, if any (see
+/// [`effective_columns`]: its own assignment, else a monitor-shape-derived
+/// `general.default_columns` rule). Called when a workspace gains focus so
+/// its layout re-asserts on switch-in. A no-op when nothing resolves or
+/// the workspace has fewer than two tiling windows.
+///
+/// `preferred_center` pins which window lands in the `C` column; pass
+/// `None` to center the focused window (switch-in, new window), or the
+/// current center (see [`workspace_center_window_id`]) to keep it stable
+/// across a reapply that shouldn't move the center, such as after a side
+/// window closes.
+///
+/// The `C` column is sized from the columns' stored `center`, which a
+/// manual resize updates at runtime (see [`store_center_width`]). Reading
+/// from the stored template keeps the center width stable across reapplies
+/// (window add/remove, switch-in) instead of drifting with the tree's
+/// transient sizes; config reload restores the spec value by replacing the
+/// config.
+pub fn reapply_assigned_columns(
+  workspace: &Workspace,
+  preferred_center: Option<Uuid>,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<()> {
+  if let Some(columns) = effective_columns(workspace, config)? {
+    apply_columns(
+      workspace,
+      &columns.spec,
+      columns.center,
+      &columns.bias,
+      preferred_center,
+      state,
+      config,
+    )?;
+  }
+
+  Ok(())
+}
+
+/// Reapplies assigned columns after a tiling window moves from `source` to
+/// `target`. The source re-tidies around `source_center` — its center
+/// before the move, captured by the caller so closing the gap doesn't
+/// shift it — and the moved window becomes the center of the target's
+/// layout. A no-op for either workspace that has no assigned columns.
+pub fn reapply_columns_after_move(
+  source: &Workspace,
+  source_center: Option<Uuid>,
+  target: &Workspace,
+  moved_window_id: Uuid,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<()> {
+  reapply_assigned_columns(source, source_center, state, config)?;
+  reapply_assigned_columns(target, Some(moved_window_id), state, config)?;
+  Ok(())
+}
+
+/// Id of the window currently in the workspace's center — the top of its
+/// widest column — if the workspace has any tiling windows. Capture this
+/// before unmanaging a closing window so a follow-up
+/// `reapply_assigned_columns` can keep that window centered.
+pub fn workspace_center_window_id(workspace: &Workspace) -> Option<Uuid> {
+  ColumnGrid::read(workspace).center_window_id()
+}
+
+/// Remembers the window leaving the center as the `center` command's
+/// swap-back target.
+///
+/// Given the `new_center` a layout is about to install, this records the
+/// window currently in the center (when different) into
+/// `state.last_centered_out`, so pressing `center` on the incoming window
+/// toggles back to the one it displaced — e.g. after a freshly opened
+/// window auto-centers.
+///
+/// Must be called while the outgoing center is still in place, before the
+/// workspace is rebuilt. A no-op when the center is unchanged or the
+/// workspace has no center yet.
+fn remember_outgoing_center(
+  workspace: &Workspace,
+  new_center: Uuid,
+  state: &mut WmState,
+) {
+  if let Some(previous) = workspace_center_window_id(workspace) {
+    if previous != new_center {
+      state.last_centered_out = Some(previous);
+    }
+  }
+}
+
+/// Current width fraction of the workspace's center column — its widest
+/// column — when it has a laid-out columns of at least two tiling windows.
+///
+/// Returns `None` for a workspace with fewer than two tiling windows,
+/// where no meaningful center width exists.
+fn workspace_center_width(workspace: &Workspace) -> Option<f32> {
+  let grid = ColumnGrid::read(workspace);
+
+  if grid.window_count() < 2 {
+    return None;
+  }
+
+  grid.center_width()
+}
+
+/// Records the workspace's current center-column width into its assigned
+/// columns, so a manual resize of the center becomes the template width
+/// used by later reapplies (window add/remove, switch-in). Call this after
+/// a user resize; the runtime value lives on the workspace config and is
+/// reset to the spec by config reload or restart.
+///
+/// A no-op when the workspace has no assigned columns or no laid-out
+/// center column (fewer than two tiling windows).
+pub fn store_center_width(workspace: &Workspace) {
+  let mut config = workspace.config();
+  let Some(columns) = config.columns.as_mut() else {
+    return;
+  };
+
+  let Some(width) = workspace_center_width(workspace) else {
+    return;
+  };
+
+  columns.center = width;
+  workspace.set_config(config);
+}
+
+/// Id of the focused tiling window on the workspace, if any.
+fn focused_window_id(workspace: &Workspace) -> Option<Uuid> {
+  workspace.descendant_focus_order().find_map(
+    |container| match container {
+      Container::TilingWindow(window) => Some(window.id()),
+      _ => None,
+    },
+  )
+}
+
+/// Rotates the windows of the focused workspace by one slot, keeping the
+/// existing column layout (column count, per-column window counts, and
+/// column widths) fixed — only the window occupying each slot changes.
+///
+/// Windows travel a clockwise loop around the center column: up the left
+/// columns, across through the center, down the right columns, then
+/// wrapping from the bottom-right slot back to the bottom-left. So for a
+/// `*,C,*` layout with 2/1/2 windows the cycle is bottom-left → top-left →
+/// center → top-right → bottom-right → back to bottom-left. Clockwise is
+/// the default; `ccw` reverses it. The focused slot stays focused, so its
+/// occupant changes under a steady highlight and repeated rotates cycle
+/// every window through it.
+pub fn apply_rotate(
+  workspace: &Workspace,
+  ccw: bool,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<()> {
+  let grid = ColumnGrid::read(workspace);
+
+  if grid.window_count() < 2 {
+    return Ok(());
+  }
+
+  // Windows loop clockwise around the center column: the columns left of
+  // center are traversed bottom-to-top (so `ring_slots` lists them
+  // reversed), then the center and right columns top-to-bottom.
+  let center = grid.center_index();
+
+  let mut ring_slots: Vec<(usize, usize)> = Vec::new();
+  for (col, column) in grid.columns.iter().enumerate().take(center) {
+    ring_slots.extend((0..column.len()).map(|row| (col, row)));
+  }
+  let left_len = ring_slots.len();
+  ring_slots[..left_len].reverse();
+  for (col, column) in grid.columns.iter().enumerate().skip(center) {
+    ring_slots.extend((0..column.len()).map(|row| (col, row)));
+  }
+
+  // The window currently in each ring slot, in ring order.
+  let ring: Vec<TilingWindow> = ring_slots
+    .iter()
+    .map(|&(c, r)| grid.columns[c][r].clone())
+    .collect();
+
+  // Remember which ring position holds focus so the same physical slot
+  // stays focused after the windows rotate beneath it.
+  let focused_pos = focused_window_id(workspace)
+    .and_then(|id| ring.iter().position(|window| window.id() == id));
+
+  // Clockwise: every window advances one slot, so slot `i` takes slot
+  // `i-1`'s former occupant (last wraps to first). Counter-clockwise is
+  // the reverse.
+  let mut rotated = ring;
+  if ccw {
+    rotated.rotate_left(1);
+  } else {
+    rotated.rotate_right(1);
+  }
+
+  let focus_target = focused_pos.map(|pos| rotated[pos].id());
+
+  // Place each rotated window back into its ring slot, preserving the
+  // exact column shape.
+  let mut columns: Vec<Vec<Option<TilingWindow>>> = grid
+    .columns
+    .iter()
+    .map(|col| vec![None; col.len()])
+    .collect();
+  for (&(c, r), window) in ring_slots.iter().zip(rotated) {
+    columns[c][r] = Some(window);
+  }
+  let columns = columns
+    .into_iter()
+    .map(|col| col.into_iter().flatten().collect())
+    .collect::<Vec<Vec<TilingWindow>>>();
+
+  ColumnGrid {
+    columns,
+    widths: grid.widths,
+  }
+  .render(workspace, state, config)?;
+
+  if let Some(id) = focus_target {
+    focus_container_by_id(&id, state)?;
+  }
+
+  Ok(())
+}
+
+/// Swaps a window into the center slot — the top of the widest column.
+///
+/// When the focused window is *not* the center, it swaps into the center
+/// and the old center takes its place; focus follows into the center. When
+/// the focused window *is* the center, it swaps back with the window most
+/// recently phased out of the center (`state.last_centered_out`), so
+/// pressing `center` repeatedly toggles between two windows. That target
+/// is maintained wherever the center changes — including a freshly opened
+/// window auto-centering (see `remember_outgoing_center`) — so the toggle
+/// can return to the previous window even when it wasn't this command that
+/// centered the current one. The window leaving the center is remembered
+/// as the next toggle target, and whichever window lands in the center
+/// gains focus. A no-op if there is no toggle target, it no longer exists,
+/// or there is nothing to swap.
+pub fn apply_center(
+  workspace: &Workspace,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<()> {
+  let mut grid = ColumnGrid::read(workspace);
+
+  if grid.window_count() < 2 {
+    return Ok(());
+  }
+
+  let center = grid.center_index();
+  if grid.columns[center].is_empty() {
+    return Ok(());
+  }
+
+  let Some(focused_id) = focused_window_id(workspace) else {
+    return Ok(());
+  };
+
+  let center_id = grid.columns[center][0].id();
+
+  // Pick the slot to swap with the center. Normally that's the focused
+  // window; if the focused window already is the center, fall back to the
+  // last window moved out of the center so `center` toggles between two.
+  let partner = if focused_id == center_id {
+    state.last_centered_out.and_then(|id| grid.find(id))
+  } else {
+    grid.find(focused_id)
+  };
+
+  let Some((pc, pr)) = partner else {
+    return Ok(());
+  };
+
+  // Nothing to do if the partner already occupies the center.
+  if (pc, pr) == (center, 0) {
+    return Ok(());
+  }
+
+  let leaving = grid.columns[center][0].clone();
+  let entering = grid.columns[pc][pr].clone();
+  grid.columns[center][0] = entering.clone();
+  grid.columns[pc][pr] = leaving.clone();
+
+  grid.render(workspace, state, config)?;
+
+  // Remember the window pushed out of the center as the next toggle
+  // target, and move focus with the window that landed in the center.
+  state.last_centered_out = Some(leaving.id());
+  focus_container_by_id(&entering.id(), state)?;
+
+  Ok(())
+}
+
+/// Moves the focused window one slot within its workspace's assigned
+/// columns grid, returning whether the move was handled here.
+///
+/// The workspace is treated as columns left-to-right, each a top-to-bottom
+/// stack of windows. Interior moves swap the focused window with a
+/// neighbouring slot: `Up`/`Down` with the window above/below it in its
+/// column, `Left`/`Right` with the nearest window (by row) in the adjacent
+/// column. Swapping keeps every column's window count fixed, so the center
+/// column — a single-window slot — always stays exactly one window: moving
+/// a side window into the center displaces the old center out to the
+/// vacated side slot, and moving the center window out promotes the side
+/// window it swaps with into the center. The result is rendered directly
+/// through `ColumnGrid::render`, so the declarative columns stay intact
+/// and the spec is not re-derived from geometry, and focus follows the
+/// moved window.
+///
+/// At a column's edge the window leaves the workspace for the monitor
+/// stacked in that direction: `Up`/`Down` past the top/bottom of a column
+/// and `Left`/`Right` past the outermost column both move the window to
+/// the adjacent monitor's displayed workspace (a no-op when there is no
+/// monitor there), re-tidying the columns left behind. This is handled
+/// here rather than by the default mover, which would either reparent the
+/// window into a new perpendicular split or re-column a window that has
+/// stacked neighbours inside this workspace — both of which break the
+/// declarative columns.
+///
+/// Returns `false` — leaving the caller to fall back to the default
+/// directional mover — only when the workspace has no effective columns
+/// (see [`effective_columns`]: its own assignment, else a monitor-shape
+/// `general.default_columns` rule) or the subject is not a tiling window
+/// in the grid.
+pub fn move_window_in_columns(
+  window: &WindowContainer,
+  direction: &Direction,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<bool> {
+  let WindowContainer::TilingWindow(tiling) = window else {
+    return Ok(false);
+  };
+
+  let Some(workspace) = tiling.workspace() else {
+    return Ok(false);
+  };
+
+  if effective_columns(&workspace, config)?.is_none() {
+    return Ok(false);
+  }
+
+  let mut grid = ColumnGrid::read(&workspace);
+  let Some((col, row)) = grid.find(tiling.id()) else {
+    return Ok(false);
+  };
+
+  match direction {
+    Direction::Up | Direction::Down => {
+      let target_row = match direction {
+        Direction::Up if row > 0 => row - 1,
+        Direction::Down if row + 1 < grid.columns[col].len() => row + 1,
+        // Top/bottom of the column: leave for the workspace of the
+        // monitor stacked in this direction (a no-op when there is none),
+        // re-tidying the columns we leave behind. As with the left/right
+        // edge, this is handled here rather than by the default mover,
+        // which would reparent the window into a new perpendicular split
+        // and break the declarative columns.
+        _ => {
+          move_to_workspace_in_direction(
+            window, direction, state, config,
+          )?;
+          return Ok(true);
+        }
+      };
+      grid.columns[col].swap(row, target_row);
+    }
+    Direction::Left | Direction::Right => {
+      let target_col = match direction {
+        Direction::Left if col > 0 => col - 1,
+        Direction::Right if col + 1 < grid.columns.len() => col + 1,
+        // Outermost column: leave for the adjacent monitor's workspace in
+        // this direction (a no-op when there is none), which re-tidies the
+        // columns we left behind. Handled here rather than by the default
+        // mover, which would re-column the window inside this workspace
+        // when it has stacked neighbours in its column.
+        _ => {
+          move_to_workspace_in_direction(
+            window, direction, state, config,
+          )?;
+          return Ok(true);
+        }
+      };
+      // Swap with the nearest window in the target column so both columns
+      // keep their window counts — the center stays a single window.
+      let target_row =
+        row.min(grid.columns[target_col].len().saturating_sub(1));
+      let moved = grid.columns[col][row].clone();
+      grid.columns[col][row] =
+        grid.columns[target_col][target_row].clone();
+      grid.columns[target_col][target_row] = moved;
+    }
+  }
+
+  grid.render(&workspace, state, config)?;
+  focus_container_by_id(&tiling.id(), state)?;
+
+  Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+  use uuid::Uuid;
+  use wm_common::{ColumnBias, ParsedConfig};
+  use wm_platform::{Direction, Rect};
+
+  use super::{
+    apply_center, apply_columns, apply_rotate, assign_columns,
+    effective_columns, focused_window_id, grid::ColumnGrid,
+    move_window_in_columns, reapply_assigned_columns, store_center_width,
+    unassign_columns, workspace_center_window_id,
+  };
+  use crate::{
+    commands::{
+      container::{attach_container, focus_container_by_id},
+      workspace::move_workspace_in_direction,
+    },
+    models::{
+      Monitor, TilingContainer, TilingWindow, WindowContainer, Workspace,
+    },
+    test_utils::{mock_user_config, mock_wm_state},
+    traits::{CommonGetters, TilingSizeGetters},
+    user_config::UserConfig,
+    wm_state::WmState,
+  };
+
+  /// A workspace of `window_count` tiling windows, live under a fresh
+  /// `WmState`'s root so id lookups and window rects resolve. Returns the
+  /// state, workspace, and the windows (in attach order).
+  fn setup(
+    window_count: usize,
+  ) -> (WmState, Workspace, Vec<TilingWindow>) {
+    let state = mock_wm_state();
+
+    let windows = (0..window_count)
+      .map(|_| TilingWindow::mock().call())
+      .collect::<Vec<_>>();
+
+    let workspace = Workspace::mock()
+      .tiling_containers(
+        windows
+          .iter()
+          .cloned()
+          .map(TilingContainer::TilingWindow)
+          .collect(),
+      )
+      .call();
+
+    let monitor =
+      Monitor::mock().workspaces(vec![workspace.clone()]).call();
+    attach_container(
+      &monitor.into(),
+      &state.root_container.clone().into(),
+      None,
+    )
+    .unwrap();
+
+    (state, workspace, windows)
+  }
+
+  /// Attaches a monitor at `bounds` holding one workspace of `count`
+  /// tiling windows under `state`'s root. Returns the workspace and its
+  /// windows. Use distinct, non-overlapping `bounds` to place monitors
+  /// adjacently so `monitor_in_direction` resolves.
+  fn add_monitor(
+    state: &WmState,
+    bounds: Rect,
+    count: usize,
+  ) -> (Workspace, Vec<TilingWindow>) {
+    let windows = (0..count)
+      .map(|_| TilingWindow::mock().call())
+      .collect::<Vec<_>>();
+
+    let workspace = Workspace::mock()
+      .tiling_containers(
+        windows
+          .iter()
+          .cloned()
+          .map(TilingContainer::TilingWindow)
+          .collect(),
+      )
+      .call();
+
+    let monitor = Monitor::mock()
+      .bounds(bounds)
+      .workspaces(vec![workspace.clone()])
+      .call();
+
+    attach_container(
+      &monitor.into(),
+      &state.root_container.clone().into(),
+      None,
+    )
+    .unwrap();
+
+    (workspace, windows)
+  }
+
+  /// A `UserConfig` whose `general.default_columns` maps wide monitors to
+  /// the given `spec` (the mock monitor's aspect ratio is ~1.6).
+  fn config_with_default_columns(spec: &str) -> UserConfig {
+    let yaml = format!(
+      "general:\n  default_columns:\n    - min_aspect_ratio: 1.5\n      spec: '{spec}'\n"
+    );
+    let value: ParsedConfig = serde_yaml::from_str(&yaml).unwrap();
+    UserConfig::mock(value)
+  }
+
+  /// The window ids in each column, top-to-bottom, left-to-right.
+  fn id_grid(workspace: &Workspace) -> Vec<Vec<Uuid>> {
+    ColumnGrid::read(workspace)
+      .columns
+      .iter()
+      .map(|column| column.iter().map(CommonGetters::id).collect())
+      .collect()
+  }
+
+  /// `*,C,*` lays 5 windows into 2/1/2 columns with the preferred center
+  /// in the wide middle column at its configured width.
+  #[test]
+  fn applies_star_center_star_layout() {
+    let (mut state, workspace, windows) = setup(5);
+    let config = mock_user_config();
+    let ids = windows.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &workspace,
+      "*,C,*",
+      0.6,
+      &ColumnBias::Left,
+      Some(ids[2]),
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    assert_eq!(
+      id_grid(&workspace),
+      vec![vec![ids[0], ids[1]], vec![ids[2]], vec![ids[3], ids[4]]]
+    );
+
+    let grid = ColumnGrid::read(&workspace);
+    assert_eq!(grid.center_index(), 1);
+    assert!((grid.center_width().unwrap() - 0.6).abs() < 1e-3);
+    assert!((grid.widths[0] - 0.2).abs() < 1e-3);
+    assert!((grid.widths[2] - 0.2).abs() < 1e-3);
+  }
+
+  /// `2,C,*` fixes the left column at two windows, centers the preferred
+  /// window, and lets the `*` column absorb the remaining three.
+  #[test]
+  fn applies_fixed_column_layout() {
+    let (mut state, workspace, windows) = setup(6);
+    let config = mock_user_config();
+    let ids = windows.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &workspace,
+      "2,C,*",
+      0.6,
+      &ColumnBias::Left,
+      Some(ids[2]),
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    assert_eq!(
+      id_grid(&workspace),
+      vec![
+        vec![ids[0], ids[1]],
+        vec![ids[2]],
+        vec![ids[3], ids[4], ids[5]],
+      ]
+    );
+
+    let grid = ColumnGrid::read(&workspace);
+    assert_eq!(grid.center_index(), 1);
+    assert!((grid.center_width().unwrap() - 0.6).abs() < 1e-3);
+    assert!((grid.widths[0] - 0.2).abs() < 1e-3);
+    assert!((grid.widths[2] - 0.2).abs() < 1e-3);
+  }
+
+  /// Clockwise rotate advances every window one slot around the center
+  /// while the 2/1/2 column shape stays fixed.
+  #[test]
+  fn rotates_windows_clockwise_keeping_shape() {
+    let (mut state, workspace, windows) = setup(5);
+    let config = mock_user_config();
+    let ids = windows.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &workspace,
+      "*,C,*",
+      0.6,
+      &ColumnBias::Left,
+      Some(ids[2]),
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    apply_rotate(&workspace, false, &mut state, &config).unwrap();
+
+    // Ring bottom-left → top-left → center → top-right → bottom-right,
+    // each slot taking its predecessor's occupant (last wraps to first).
+    assert_eq!(
+      id_grid(&workspace),
+      vec![vec![ids[1], ids[4]], vec![ids[0]], vec![ids[2], ids[3]]]
+    );
+  }
+
+  /// Counter-clockwise rotate is the exact reverse.
+  #[test]
+  fn rotates_windows_counter_clockwise() {
+    let (mut state, workspace, windows) = setup(5);
+    let config = mock_user_config();
+    let ids = windows.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &workspace,
+      "*,C,*",
+      0.6,
+      &ColumnBias::Left,
+      Some(ids[2]),
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    apply_rotate(&workspace, true, &mut state, &config).unwrap();
+
+    assert_eq!(
+      id_grid(&workspace),
+      vec![vec![ids[2], ids[0]], vec![ids[3]], vec![ids[4], ids[1]]]
+    );
+  }
+
+  /// `center` swaps the focused side window into the center (focus
+  /// follows), then toggles back to the displaced window on a repeat
+  /// press.
+  #[test]
+  fn center_swaps_focused_then_toggles_back() {
+    let (mut state, workspace, windows) = setup(5);
+    let config = mock_user_config();
+    let ids = windows.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &workspace,
+      "*,C,*",
+      0.6,
+      &ColumnBias::Left,
+      Some(ids[2]),
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    // Focus a side window and center it: it swaps with the old center.
+    focus_container_by_id(&ids[0], &mut state).unwrap();
+    apply_center(&workspace, &mut state, &config).unwrap();
+
+    assert_eq!(
+      id_grid(&workspace),
+      vec![vec![ids[2], ids[1]], vec![ids[0]], vec![ids[3], ids[4]]]
+    );
+    assert_eq!(focused_window_id(&workspace), Some(ids[0]));
+    assert_eq!(state.last_centered_out, Some(ids[2]));
+
+    // Focused window is now the center, so `center` toggles it back with
+    // the window it displaced.
+    apply_center(&workspace, &mut state, &config).unwrap();
+
+    assert_eq!(
+      id_grid(&workspace),
+      vec![vec![ids[0], ids[1]], vec![ids[2]], vec![ids[3], ids[4]]]
+    );
+    assert_eq!(focused_window_id(&workspace), Some(ids[2]));
+    assert_eq!(state.last_centered_out, Some(ids[0]));
+  }
+
+  /// `Up`/`Down` swaps a window with its vertical neighbour in the column.
+  #[test]
+  fn moves_window_within_column() {
+    let (mut state, workspace, windows) = setup(5);
+    // `move_window_in_columns` only runs when the workspace has effective
+    // columns; a matching `default_columns` rule provides that.
+    let config = config_with_default_columns("*,C,*");
+    let ids = windows.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &workspace,
+      "*,C,*",
+      0.6,
+      &ColumnBias::Left,
+      Some(ids[2]),
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    let window = WindowContainer::TilingWindow(windows[1].clone());
+    let handled =
+      move_window_in_columns(&window, &Direction::Up, &mut state, &config)
+        .unwrap();
+
+    assert!(handled);
+    assert_eq!(
+      id_grid(&workspace),
+      vec![vec![ids[1], ids[0]], vec![ids[2]], vec![ids[3], ids[4]]]
+    );
+  }
+
+  /// Moving a side window into the center displaces the old center out to
+  /// the vacated slot, keeping the center a single window.
+  #[test]
+  fn moves_into_center_keeps_it_single_window() {
+    let (mut state, workspace, windows) = setup(5);
+    let config = config_with_default_columns("*,C,*");
+    let ids = windows.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &workspace,
+      "*,C,*",
+      0.6,
+      &ColumnBias::Left,
+      Some(ids[2]),
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    let window = WindowContainer::TilingWindow(windows[0].clone());
+    let handled = move_window_in_columns(
+      &window,
+      &Direction::Right,
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    assert!(handled);
+    assert_eq!(
+      id_grid(&workspace),
+      vec![vec![ids[2], ids[1]], vec![ids[0]], vec![ids[3], ids[4]]]
+    );
+  }
+
+  /// `move` within a fixed-column layout swaps window-for-window: `Down`
+  /// reorders the fixed column's stack, and `Right` into the center keeps
+  /// the fixed column at two windows and the center at one.
+  #[test]
+  fn moves_within_fixed_column_layout() {
+    let (mut state, workspace, windows) = setup(6);
+    let config = config_with_default_columns("2,C,*");
+    let ids = windows.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &workspace,
+      "2,C,*",
+      0.6,
+      &ColumnBias::Left,
+      Some(ids[2]),
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    // `Down` swaps the two windows stacked in the fixed left column.
+    let top = WindowContainer::TilingWindow(windows[0].clone());
+    assert!(move_window_in_columns(
+      &top,
+      &Direction::Down,
+      &mut state,
+      &config
+    )
+    .unwrap());
+    assert_eq!(
+      id_grid(&workspace),
+      vec![
+        vec![ids[1], ids[0]],
+        vec![ids[2]],
+        vec![ids[3], ids[4], ids[5]],
+      ]
+    );
+
+    // `Right` moves the fixed column's bottom window into the center,
+    // displacing the old center into the vacated slot. Counts are
+    // preserved: the fixed column keeps two, the center keeps one.
+    let bottom = WindowContainer::TilingWindow(windows[0].clone());
+    assert!(move_window_in_columns(
+      &bottom,
+      &Direction::Right,
+      &mut state,
+      &config
+    )
+    .unwrap());
+    assert_eq!(
+      id_grid(&workspace),
+      vec![
+        vec![ids[1], ids[2]],
+        vec![ids[0]],
+        vec![ids[3], ids[4], ids[5]],
+      ]
+    );
+  }
+
+  /// Moving off the outermost column sends the window to the adjacent
+  /// monitor's workspace: the source re-tidies keeping its center, and the
+  /// moved window becomes the target's center. (`Left` is symmetric.)
+  #[test]
+  fn moves_out_to_horizontally_adjacent_monitor() {
+    let mut state = mock_wm_state();
+    let config = config_with_default_columns("*,C,*");
+
+    // Two 1680x1050 monitors side by side (aspect ~1.6, so both match the
+    // default-columns rule).
+    let (ws_left, wins_left) =
+      add_monitor(&state, Rect::from_xy(0, 0, 1680, 1050), 5);
+    let (ws_right, _wins_right) =
+      add_monitor(&state, Rect::from_xy(1680, 0, 1680, 1050), 2);
+    let ids = wins_left.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &ws_left,
+      "*,C,*",
+      0.6,
+      &ColumnBias::Left,
+      Some(ids[2]),
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    // `ids[3]` sits in the rightmost column; moving it `Right` leaves the
+    // workspace for the monitor to the right.
+    let window = WindowContainer::TilingWindow(wins_left[3].clone());
+    let handled = move_window_in_columns(
+      &window,
+      &Direction::Right,
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    assert!(handled);
+    assert_eq!(
+      wins_left[3].workspace().map(|w| w.id()),
+      Some(ws_right.id())
+    );
+    // Source keeps its center; target adopts the arrival as its center.
+    assert_eq!(workspace_center_window_id(&ws_left), Some(ids[2]));
+    assert_eq!(workspace_center_window_id(&ws_right), Some(ids[3]));
+  }
+
+  /// The same edge hand-off works vertically: moving off the bottom row
+  /// sends the window to the monitor below. (`Up` is symmetric.)
+  #[test]
+  fn moves_out_to_vertically_adjacent_monitor() {
+    let mut state = mock_wm_state();
+    let config = config_with_default_columns("*,C,*");
+
+    // Two monitors stacked top/bottom.
+    let (ws_top, wins_top) =
+      add_monitor(&state, Rect::from_xy(0, 0, 1680, 1050), 5);
+    let (ws_bottom, _wins_bottom) =
+      add_monitor(&state, Rect::from_xy(0, 1050, 1680, 1050), 2);
+    let ids = wins_top.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &ws_top,
+      "*,C,*",
+      0.6,
+      &ColumnBias::Left,
+      Some(ids[2]),
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    // `ids[1]` is the bottom of the left column; `Down` leaves for the
+    // monitor below.
+    let window = WindowContainer::TilingWindow(wins_top[1].clone());
+    let handled = move_window_in_columns(
+      &window,
+      &Direction::Down,
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    assert!(handled);
+    assert_eq!(
+      wins_top[1].workspace().map(|w| w.id()),
+      Some(ws_bottom.id())
+    );
+    assert_eq!(workspace_center_window_id(&ws_top), Some(ids[2]));
+    assert_eq!(workspace_center_window_id(&ws_bottom), Some(ids[1]));
+  }
+
+  /// Moving a workspace to a differently-shaped monitor via the real
+  /// `move_workspace_in_direction` command re-resolves its
+  /// `general.default_columns` and reapplies that monitor's layout. This
+  /// covers the command's own reparent + reapply wiring, not just the
+  /// resolution in isolation.
+  #[test]
+  fn workspace_recolumns_when_moved_to_monitor_with_different_aspect() {
+    let mut state = mock_wm_state();
+
+    // Ultrawide (2.1+) → `*,C,*`; standard widescreen (1.5+) → `C,*`.
+    let yaml = "general:\n  default_columns:\n    - min_aspect_ratio: 2.1\n      spec: '*,C,*'\n    - min_aspect_ratio: 1.5\n      spec: 'C,*'\n";
+    let value: ParsedConfig = serde_yaml::from_str(yaml).unwrap();
+    let config = UserConfig::mock(value);
+
+    // Ultrawide 3440x1440 (~2.39) with the workspace under test plus a
+    // second workspace, so moving the first out doesn't empty the monitor
+    // (which would need a workspace config to backfill). Standard
+    // 1920x1080 (~1.78) sits to its right.
+    let (workspace, _wins) =
+      add_monitor(&state, Rect::from_xy(0, 0, 3440, 1440), 3);
+    let ultrawide = workspace.monitor().unwrap();
+    let filler = Workspace::mock().name("filler".to_string()).call();
+    attach_container(&filler.into(), &ultrawide.clone().into(), None)
+      .unwrap();
+    add_monitor(&state, Rect::from_xy(3440, 0, 1920, 1080), 0);
+
+    // On the ultrawide, the workspace resolves and applies the 3-column
+    // layout.
+    reapply_assigned_columns(&workspace, None, &mut state, &config)
+      .unwrap();
+    assert_eq!(ColumnGrid::read(&workspace).columns.len(), 3);
+
+    // Move it right onto the standard monitor with the real command.
+    move_workspace_in_direction(
+      &workspace,
+      &Direction::Right,
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    // The command re-resolved the layout for the new monitor: a 2-column
+    // `C,*`, with the moved window kept centered.
+    assert_eq!(
+      effective_columns(&workspace, &config)
+        .unwrap()
+        .map(|c| c.spec),
+      Some("C,*".to_string())
+    );
+    assert_eq!(ColumnGrid::read(&workspace).columns.len(), 2);
+  }
+
+  /// Without effective columns the move is not handled here, so the caller
+  /// falls back to the default directional mover.
+  #[test]
+  fn move_without_columns_is_not_handled() {
+    let (mut state, _workspace, windows) = setup(3);
+    let config = mock_user_config();
+
+    let window = WindowContainer::TilingWindow(windows[0].clone());
+    let handled = move_window_in_columns(
+      &window,
+      &Direction::Left,
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    assert!(!handled);
+  }
+
+  /// A workspace with no assignment inherits the monitor-shape default.
+  #[test]
+  fn effective_columns_uses_default_when_unassigned() {
+    let (_state, workspace, _windows) = setup(2);
+    let config = config_with_default_columns("C,*");
+
+    let columns = effective_columns(&workspace, &config).unwrap();
+    assert_eq!(columns.map(|c| c.spec), Some("C,*".to_string()));
+  }
+
+  /// An explicit assignment wins over the monitor-shape default.
+  #[test]
+  fn effective_columns_prefers_assignment() {
+    let (mut state, workspace, _windows) = setup(2);
+    let config = config_with_default_columns("*,C,*");
+
+    assign_columns(
+      &workspace,
+      "1,C",
+      0.6,
+      &ColumnBias::Left,
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    let columns = effective_columns(&workspace, &config).unwrap();
+    assert_eq!(columns.map(|c| c.spec), Some("1,C".to_string()));
+  }
+
+  /// Unassigning clears the workspace's columns so it no longer resolves
+  /// an assignment.
+  #[test]
+  fn unassign_clears_assignment() {
+    let (mut state, workspace, _windows) = setup(2);
+    let config = mock_user_config();
+
+    assign_columns(
+      &workspace,
+      "*,C,*",
+      0.6,
+      &ColumnBias::Left,
+      &mut state,
+      &config,
+    )
+    .unwrap();
+    assert!(workspace.config().columns.is_some());
+
+    unassign_columns(&workspace);
+    assert!(workspace.config().columns.is_none());
+  }
+
+  /// The center window id is the top of the widest column.
+  #[test]
+  fn reports_center_window_id() {
+    let (mut state, workspace, windows) = setup(5);
+    let config = mock_user_config();
+    let ids = windows.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &workspace,
+      "*,C,*",
+      0.6,
+      &ColumnBias::Left,
+      Some(ids[2]),
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    assert_eq!(workspace_center_window_id(&workspace), Some(ids[2]));
+  }
+
+  /// A manual resize of the center is captured into the assignment so
+  /// later reapplies use the new width.
+  #[test]
+  fn store_center_width_records_resize() {
+    let (mut state, workspace, windows) = setup(5);
+    let config = mock_user_config();
+
+    assign_columns(
+      &workspace,
+      "*,C,*",
+      0.6,
+      &ColumnBias::Left,
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    // Simulate the user widening the center column (a single-window
+    // column, so its window's tiling size is the column width).
+    let center_id = workspace_center_window_id(&workspace).unwrap();
+    let center = windows
+      .iter()
+      .find(|window| window.id() == center_id)
+      .unwrap();
+    center.set_tiling_size(0.7);
+    store_center_width(&workspace);
+
+    let stored = workspace.config().columns.unwrap().center;
+    assert!((stored - 0.7).abs() < 1e-3);
+  }
+}

--- a/packages/wm/src/commands/workspace/columns/mod.rs
+++ b/packages/wm/src/commands/workspace/columns/mod.rs
@@ -13,11 +13,13 @@ mod spec;
 use anyhow::Context;
 use uuid::Uuid;
 use wm_common::{ColumnBias, ColumnLayout};
-use wm_platform::Direction;
+use wm_platform::{Direction, Rect};
 
 use self::{
   grid::ColumnGrid,
-  spec::{column_widths, distribute_columns, parse_columns_spec},
+  spec::{
+    column_widths, distribute_columns, parse_columns_spec, ColumnKind,
+  },
 };
 use crate::{
   commands::{
@@ -34,9 +36,11 @@ use crate::{
 /// by a comma-separated column `spec`, laid out left-to-right. Each token
 /// is one column: a number is that many windows stacked, `*` claims an
 /// even share of the leftover windows, and `C` is the wide center (the
-/// focused window; exactly one). E.g. `*,C,*` is a center flanked by two
+/// focused window; at most one). E.g. `*,C,*` is a center flanked by two
 /// even stacks, `C,*` drops the left band for a narrow monitor, and
-/// `2,1,C,3` is fully explicit.
+/// `2,1,C,3` is fully explicit. `C` is optional: a spec without one (e.g.
+/// `*,*` or `2,2`) lays the windows into plain equal-width columns with no
+/// wide center — `center` is ignored and no window is privileged.
 ///
 /// The center window fills the `C` column at `center` width (a fraction of
 /// the workspace, clamped to `0.1..=0.9`); the remaining columns split the
@@ -80,32 +84,40 @@ pub fn apply_columns(
     window.to_rect().map_or((0, 0), |rect| (rect.x(), rect.y()))
   });
 
-  // Center = the preferred center window if it's still present, else the
-  // focused tiling window, else the middle one by position.
-  let focused_id = focused_window_id(workspace);
+  let columns = if kinds.iter().any(|k| matches!(k, ColumnKind::Center)) {
+    // Center = the preferred center window if it's still present, else the
+    // focused tiling window, else the middle one by position.
+    let focused_id = focused_window_id(workspace);
 
-  let center_index = preferred_center
-    .and_then(|id| windows.iter().position(|window| window.id() == id))
-    .or_else(|| {
-      focused_id
-        .and_then(|id| windows.iter().position(|window| window.id() == id))
-    })
-    .unwrap_or(windows.len() / 2);
+    let center_index = preferred_center
+      .and_then(|id| windows.iter().position(|window| window.id() == id))
+      .or_else(|| {
+        focused_id.and_then(|id| {
+          windows.iter().position(|window| window.id() == id)
+        })
+      })
+      .unwrap_or(windows.len() / 2);
 
-  let center_window = windows[center_index].clone();
+    let center_window = windows[center_index].clone();
 
-  // A different window is taking the center, so the one it phases out
-  // becomes the `center` toggle's swap-back target.
-  remember_outgoing_center(workspace, center_window.id(), state);
+    // A different window is taking the center, so the one it phases out
+    // becomes the `center` toggle's swap-back target.
+    remember_outgoing_center(workspace, center_window.id(), state);
 
-  let rest = windows
-    .iter()
-    .enumerate()
-    .filter(|(index, _)| *index != center_index)
-    .map(|(_, window)| window.clone())
-    .collect::<Vec<_>>();
+    let rest = windows
+      .iter()
+      .enumerate()
+      .filter(|(index, _)| *index != center_index)
+      .map(|(_, window)| window.clone())
+      .collect::<Vec<_>>();
 
-  let columns = distribute_columns(&kinds, center_window, rest, bias);
+    distribute_columns(&kinds, Some(center_window), rest, bias)
+  } else {
+    // No `C`: every window flows into the equal-width columns in on-screen
+    // order and none is pulled out as a privileged center.
+    distribute_columns(&kinds, None, windows, bias)
+  };
+
   let widths = column_widths(&kinds, center.clamp(0.1, 0.9));
 
   ColumnGrid { columns, widths }.render(workspace, state, config)
@@ -193,25 +205,31 @@ pub fn effective_columns(
 /// (window add/remove, switch-in) instead of drifting with the tree's
 /// transient sizes; config reload restores the spec value by replacing the
 /// config.
+///
+/// Returns whether a layout was reapplied (i.e. the workspace has
+/// effective columns), so callers can follow up — e.g. resetting window
+/// effects.
 pub fn reapply_assigned_columns(
   workspace: &Workspace,
   preferred_center: Option<Uuid>,
   state: &mut WmState,
   config: &UserConfig,
-) -> anyhow::Result<()> {
-  if let Some(columns) = effective_columns(workspace, config)? {
-    apply_columns(
-      workspace,
-      &columns.spec,
-      columns.center,
-      &columns.bias,
-      preferred_center,
-      state,
-      config,
-    )?;
-  }
+) -> anyhow::Result<bool> {
+  let Some(columns) = effective_columns(workspace, config)? else {
+    return Ok(false);
+  };
 
-  Ok(())
+  apply_columns(
+    workspace,
+    &columns.spec,
+    columns.center,
+    &columns.bias,
+    preferred_center,
+    state,
+    config,
+  )?;
+
+  Ok(true)
 }
 
 /// Reapplies assigned columns after a tiling window moves from `source` to
@@ -238,6 +256,21 @@ pub fn reapply_columns_after_move(
 /// `reapply_assigned_columns` can keep that window centered.
 pub fn workspace_center_window_id(workspace: &Workspace) -> Option<Uuid> {
   ColumnGrid::read(workspace).center_window_id()
+}
+
+/// On-screen rect of the workspace's wide center window — the top of its
+/// widest column — or `None` when the layout has no center (equal-width
+/// columns, or fewer than two windows). Capture this before a drag drops a
+/// window back into tiling so the follow-up reapply can tell whether the
+/// drop landed on the center band and should take it over.
+pub fn workspace_center_rect(workspace: &Workspace) -> Option<Rect> {
+  let grid = ColumnGrid::read(workspace);
+  if !grid.has_center() {
+    return None;
+  }
+
+  let center = grid.center_index();
+  grid.columns.get(center)?.first()?.to_rect().ok()
 }
 
 /// Remembers the window leaving the center as the `center` command's
@@ -423,6 +456,12 @@ pub fn apply_center(
   let mut grid = ColumnGrid::read(workspace);
 
   if grid.window_count() < 2 {
+    return Ok(());
+  }
+
+  // Equal-width columns (a `C`-less layout) have no wide center to swap
+  // into, so `center` is a no-op there.
+  if !grid.has_center() {
     return Ok(());
   }
 
@@ -694,6 +733,29 @@ mod tests {
       .collect()
   }
 
+  /// The focused window that becomes the center keeps focus across the
+  /// layout rebuild — the columns layer never drops focus on its own.
+  #[test]
+  fn apply_columns_preserves_focused_window() {
+    let (mut state, workspace, windows) = setup(5);
+    let config = mock_user_config();
+    let ids = windows.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    focus_container_by_id(&ids[0], &mut state).unwrap();
+    apply_columns(
+      &workspace,
+      "*,C,*",
+      0.6,
+      &ColumnBias::Left,
+      None,
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    assert_eq!(focused_window_id(&workspace), Some(ids[0]));
+  }
+
   /// `*,C,*` lays 5 windows into 2/1/2 columns with the preferred center
   /// in the wide middle column at its configured width.
   #[test]
@@ -758,6 +820,62 @@ mod tests {
     assert!((grid.center_width().unwrap() - 0.6).abs() < 1e-3);
     assert!((grid.widths[0] - 0.2).abs() < 1e-3);
     assert!((grid.widths[2] - 0.2).abs() < 1e-3);
+  }
+
+  /// A spec with no `C` lays every window into equal-width columns and
+  /// pulls none of them out as a wide center.
+  #[test]
+  fn applies_equal_width_columns_without_center() {
+    let (mut state, workspace, windows) = setup(4);
+    let config = mock_user_config();
+    let ids = windows.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &workspace,
+      "*,*",
+      0.6,
+      &ColumnBias::Left,
+      None,
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    assert_eq!(
+      id_grid(&workspace),
+      vec![vec![ids[0], ids[1]], vec![ids[2], ids[3]]]
+    );
+
+    let grid = ColumnGrid::read(&workspace);
+    assert!(!grid.has_center());
+    assert!((grid.widths[0] - 0.5).abs() < 1e-3);
+    assert!((grid.widths[1] - 0.5).abs() < 1e-3);
+  }
+
+  /// `center` has no wide column to swap into under an equal-width layout,
+  /// so it leaves the grid untouched even with a window focused.
+  #[test]
+  fn center_is_noop_without_center() {
+    let (mut state, workspace, windows) = setup(4);
+    let config = mock_user_config();
+    let ids = windows.iter().map(CommonGetters::id).collect::<Vec<_>>();
+
+    apply_columns(
+      &workspace,
+      "*,*",
+      0.6,
+      &ColumnBias::Left,
+      None,
+      &mut state,
+      &config,
+    )
+    .unwrap();
+
+    focus_container_by_id(&ids[0], &mut state).unwrap();
+    let before = id_grid(&workspace);
+    apply_center(&workspace, &mut state, &config).unwrap();
+
+    assert_eq!(id_grid(&workspace), before);
   }
 
   /// Clockwise rotate advances every window one slot around the center

--- a/packages/wm/src/commands/workspace/columns/spec.rs
+++ b/packages/wm/src/commands/workspace/columns/spec.rs
@@ -1,0 +1,251 @@
+//! Parsing and window-distribution for `columns` specs.
+//!
+//! Pure layout math with no dependency on the window tree, so the
+//! assignment can be unit-tested with plain indices in place of live
+//! windows.
+
+use wm_common::ColumnBias;
+
+/// One column in a `columns` spec.
+#[derive(Debug, PartialEq)]
+pub(super) enum ColumnKind {
+  /// The wide center column holding the focused window.
+  Center,
+  /// A stack of exactly `n` windows.
+  Fixed(usize),
+  /// A stack claiming an even share of the windows left over after the
+  /// fixed columns take theirs.
+  Star,
+}
+
+/// Parses a comma-separated column `spec` into an ordered list of column
+/// kinds, left-to-right. A number token is that many stacked windows, `*`
+/// is a leftover-sharing stack, and `C` is the wide center.
+///
+/// Errors on an unrecognised token, a zero fixed count, or a spec that
+/// does not contain exactly one `C`.
+pub(super) fn parse_columns_spec(
+  spec: &str,
+) -> anyhow::Result<Vec<ColumnKind>> {
+  let mut kinds = Vec::new();
+  for token in spec.split(',').map(str::trim).filter(|t| !t.is_empty()) {
+    if token.eq_ignore_ascii_case("c") {
+      kinds.push(ColumnKind::Center);
+    } else if token == "*" {
+      kinds.push(ColumnKind::Star);
+    } else {
+      let count = token.parse::<usize>().map_err(|_| {
+        anyhow::anyhow!("Column `{token}` must be a number, `*`, or `C`.")
+      })?;
+      if count == 0 {
+        anyhow::bail!("Column count must be at least 1.");
+      }
+      kinds.push(ColumnKind::Fixed(count));
+    }
+  }
+
+  if kinds
+    .iter()
+    .filter(|k| matches!(k, ColumnKind::Center))
+    .count()
+    != 1
+  {
+    anyhow::bail!("Column spec must contain exactly one `C`.");
+  }
+
+  Ok(kinds)
+}
+
+/// Distributes `center` and the `rest` of the windows into columns per the
+/// parsed `kinds`, in on-screen order.
+///
+/// `center` fills the `C` column; each fixed column takes its exact count;
+/// `*` columns share the leftover windows evenly, with `bias` deciding
+/// which end claims the odd window(s) when they don't divide evenly. Any
+/// windows still unplaced (fixed counts under-specify the total and there
+/// is no `*`) are appended to the last non-center column, so nothing is
+/// dropped.
+///
+/// Generic over the item so the assignment can be unit-tested with plain
+/// indices in place of live windows.
+pub(super) fn distribute_columns<T: Clone>(
+  kinds: &[ColumnKind],
+  center: T,
+  rest: Vec<T>,
+  bias: &ColumnBias,
+) -> Vec<Vec<T>> {
+  // The `*` columns share whatever the fixed columns don't claim.
+  let fixed_total = kinds
+    .iter()
+    .map(|k| match k {
+      ColumnKind::Fixed(n) => *n,
+      _ => 0,
+    })
+    .sum::<usize>();
+  let star_count = kinds
+    .iter()
+    .filter(|k| matches!(k, ColumnKind::Star))
+    .count();
+  let leftover = rest.len().saturating_sub(fixed_total);
+  let star_base = leftover.checked_div(star_count).unwrap_or(0);
+  let star_extra = leftover.checked_rem(star_count).unwrap_or(0);
+
+  let mut rest_iter = rest.into_iter();
+  let mut stars_seen = 0;
+  let mut columns = Vec::with_capacity(kinds.len());
+  for kind in kinds {
+    match kind {
+      ColumnKind::Center => columns.push(vec![center.clone()]),
+      ColumnKind::Fixed(n) => {
+        columns.push(rest_iter.by_ref().take(*n).collect());
+      }
+      ColumnKind::Star => {
+        // The odd leftover windows go to the first `star_extra` stars for
+        // a left bias, or the last `star_extra` stars for a right bias.
+        let gets_extra = match bias {
+          ColumnBias::Left => stars_seen < star_extra,
+          ColumnBias::Right => stars_seen >= star_count - star_extra,
+        };
+        let take = star_base + usize::from(gets_extra);
+        stars_seen += 1;
+        columns.push(rest_iter.by_ref().take(take).collect());
+      }
+    }
+  }
+
+  let remaining = rest_iter.collect::<Vec<_>>();
+  if !remaining.is_empty() {
+    let target = kinds
+      .iter()
+      .rposition(|k| !matches!(k, ColumnKind::Center))
+      .unwrap_or(0);
+    columns[target].extend(remaining);
+  }
+
+  columns
+}
+
+/// The width fraction of each column: the center takes `center_fraction`
+/// and the remaining width is divided evenly across the non-center
+/// columns.
+#[allow(clippy::cast_precision_loss)]
+pub(super) fn column_widths(
+  kinds: &[ColumnKind],
+  center_fraction: f32,
+) -> Vec<f32> {
+  let non_center = kinds.len().saturating_sub(1);
+  let side = if non_center > 0 {
+    (1.0 - center_fraction) / non_center as f32
+  } else {
+    0.0
+  };
+
+  kinds
+    .iter()
+    .map(|kind| match kind {
+      ColumnKind::Center => center_fraction,
+      _ => side,
+    })
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use wm_common::ColumnBias;
+
+  use super::{
+    column_widths, distribute_columns, parse_columns_spec, ColumnKind,
+  };
+
+  #[test]
+  fn parses_star_center_star() {
+    assert_eq!(
+      parse_columns_spec("*,C,*").unwrap(),
+      vec![ColumnKind::Star, ColumnKind::Center, ColumnKind::Star]
+    );
+  }
+
+  #[test]
+  fn parses_explicit_and_lowercase_center() {
+    assert_eq!(
+      parse_columns_spec("2,1,c,3").unwrap(),
+      vec![
+        ColumnKind::Fixed(2),
+        ColumnKind::Fixed(1),
+        ColumnKind::Center,
+        ColumnKind::Fixed(3),
+      ]
+    );
+  }
+
+  #[test]
+  fn rejects_bad_specs() {
+    // No center.
+    assert!(parse_columns_spec("*,*").is_err());
+    // More than one center.
+    assert!(parse_columns_spec("C,C").is_err());
+    // Zero fixed count.
+    assert!(parse_columns_spec("0,C").is_err());
+    // Unparseable token.
+    assert!(parse_columns_spec("x,C").is_err());
+  }
+
+  #[test]
+  fn distributes_even_stars() {
+    // `*,C,*` with 4 side windows → two even stacks flanking the center.
+    let kinds = parse_columns_spec("*,C,*").unwrap();
+    let columns =
+      distribute_columns(&kinds, 0, vec![1, 2, 3, 4], &ColumnBias::Left);
+    assert_eq!(columns, vec![vec![1, 2], vec![0], vec![3, 4]]);
+  }
+
+  #[test]
+  fn bias_breaks_uneven_star_split() {
+    let kinds = parse_columns_spec("*,C,*").unwrap();
+
+    // Odd leftover: left bias gives the extra window to the first stack.
+    let left =
+      distribute_columns(&kinds, 0, vec![1, 2, 3], &ColumnBias::Left);
+    assert_eq!(left, vec![vec![1, 2], vec![0], vec![3]]);
+
+    // Right bias gives it to the last stack.
+    let right =
+      distribute_columns(&kinds, 0, vec![1, 2, 3], &ColumnBias::Right);
+    assert_eq!(right, vec![vec![1], vec![0], vec![2, 3]]);
+  }
+
+  #[test]
+  fn appends_unplaced_windows_to_last_non_center_column() {
+    // `1,C` places one window in the fixed column and no `*` to absorb the
+    // rest, so the leftovers land in the last non-center column.
+    let kinds = parse_columns_spec("1,C").unwrap();
+    let columns =
+      distribute_columns(&kinds, 0, vec![1, 2, 3], &ColumnBias::Left);
+    assert_eq!(columns, vec![vec![1, 2, 3], vec![0]]);
+  }
+
+  #[test]
+  fn fixed_column_takes_exact_count_and_star_takes_rest() {
+    // `2,C,*`: the fixed column takes exactly two windows and the `*`
+    // column absorbs the remaining three.
+    let kinds = parse_columns_spec("2,C,*").unwrap();
+    let columns = distribute_columns(
+      &kinds,
+      0,
+      vec![1, 2, 3, 4, 5],
+      &ColumnBias::Left,
+    );
+    assert_eq!(columns, vec![vec![1, 2], vec![0], vec![3, 4, 5]]);
+  }
+
+  #[test]
+  fn widths_split_remainder_evenly() {
+    let kinds = parse_columns_spec("*,C,*").unwrap();
+    let widths = column_widths(&kinds, 0.6);
+
+    assert_eq!(widths.len(), 3);
+    assert!((widths[0] - 0.2).abs() < f32::EPSILON);
+    assert!((widths[1] - 0.6).abs() < f32::EPSILON);
+    assert!((widths[2] - 0.2).abs() < f32::EPSILON);
+  }
+}

--- a/packages/wm/src/commands/workspace/columns/spec.rs
+++ b/packages/wm/src/commands/workspace/columns/spec.rs
@@ -22,8 +22,9 @@ pub(super) enum ColumnKind {
 /// kinds, left-to-right. A number token is that many stacked windows, `*`
 /// is a leftover-sharing stack, and `C` is the wide center.
 ///
-/// Errors on an unrecognised token, a zero fixed count, or a spec that
-/// does not contain exactly one `C`.
+/// Errors on an unrecognised token, a zero fixed count, or a spec with
+/// more than one `C`. A `C` is optional: a spec without one lays the
+/// windows out as plain equal-width columns with no wide center.
 pub(super) fn parse_columns_spec(
   spec: &str,
 ) -> anyhow::Result<Vec<ColumnKind>> {
@@ -48,9 +49,9 @@ pub(super) fn parse_columns_spec(
     .iter()
     .filter(|k| matches!(k, ColumnKind::Center))
     .count()
-    != 1
+    > 1
   {
-    anyhow::bail!("Column spec must contain exactly one `C`.");
+    anyhow::bail!("Column spec must contain at most one `C`.");
   }
 
   Ok(kinds)
@@ -59,18 +60,18 @@ pub(super) fn parse_columns_spec(
 /// Distributes `center` and the `rest` of the windows into columns per the
 /// parsed `kinds`, in on-screen order.
 ///
-/// `center` fills the `C` column; each fixed column takes its exact count;
-/// `*` columns share the leftover windows evenly, with `bias` deciding
-/// which end claims the odd window(s) when they don't divide evenly. Any
-/// windows still unplaced (fixed counts under-specify the total and there
-/// is no `*`) are appended to the last non-center column, so nothing is
-/// dropped.
+/// `center` (present iff `kinds` has a `C`) fills the `C` column; each
+/// fixed column takes its exact count; `*` columns share the leftover
+/// windows evenly, with `bias` deciding which end claims the odd window(s)
+/// when they don't divide evenly. Any windows still unplaced (fixed counts
+/// under-specify the total and there is no `*`) are appended to the last
+/// non-center column, so nothing is dropped.
 ///
 /// Generic over the item so the assignment can be unit-tested with plain
 /// indices in place of live windows.
-pub(super) fn distribute_columns<T: Clone>(
+pub(super) fn distribute_columns<T>(
   kinds: &[ColumnKind],
-  center: T,
+  mut center: Option<T>,
   rest: Vec<T>,
   bias: &ColumnBias,
 ) -> Vec<Vec<T>> {
@@ -95,7 +96,9 @@ pub(super) fn distribute_columns<T: Clone>(
   let mut columns = Vec::with_capacity(kinds.len());
   for kind in kinds {
     match kind {
-      ColumnKind::Center => columns.push(vec![center.clone()]),
+      ColumnKind::Center => columns.push(vec![center
+        .take()
+        .expect("a `C` column requires a center window")]),
       ColumnKind::Fixed(n) => {
         columns.push(rest_iter.by_ref().take(*n).collect());
       }
@@ -127,12 +130,23 @@ pub(super) fn distribute_columns<T: Clone>(
 
 /// The width fraction of each column: the center takes `center_fraction`
 /// and the remaining width is divided evenly across the non-center
-/// columns.
+/// columns. With no center column, `center_fraction` is ignored and every
+/// column takes an equal `1/n` share.
 #[allow(clippy::cast_precision_loss)]
 pub(super) fn column_widths(
   kinds: &[ColumnKind],
   center_fraction: f32,
 ) -> Vec<f32> {
+  let has_center = kinds.iter().any(|k| matches!(k, ColumnKind::Center));
+  if !has_center {
+    let share = if kinds.is_empty() {
+      0.0
+    } else {
+      1.0 / kinds.len() as f32
+    };
+    return vec![share; kinds.len()];
+  }
+
   let non_center = kinds.len().saturating_sub(1);
   let side = if non_center > 0 {
     (1.0 - center_fraction) / non_center as f32
@@ -180,8 +194,6 @@ mod tests {
 
   #[test]
   fn rejects_bad_specs() {
-    // No center.
-    assert!(parse_columns_spec("*,*").is_err());
     // More than one center.
     assert!(parse_columns_spec("C,C").is_err());
     // Zero fixed count.
@@ -191,11 +203,41 @@ mod tests {
   }
 
   #[test]
+  fn accepts_spec_without_center() {
+    // A center is optional: no `C` yields plain equal-width columns.
+    assert_eq!(
+      parse_columns_spec("*,*").unwrap(),
+      vec![ColumnKind::Star, ColumnKind::Star]
+    );
+    assert_eq!(
+      parse_columns_spec("2,2").unwrap(),
+      vec![ColumnKind::Fixed(2), ColumnKind::Fixed(2)]
+    );
+  }
+
+  #[test]
+  fn widths_are_equal_without_center() {
+    // Without a `C`, every column takes an equal share and `center` is
+    // ignored — the widths sum to 1 across `n` columns.
+    let kinds = parse_columns_spec("*,*,*").unwrap();
+    let widths = column_widths(&kinds, 0.6);
+
+    assert_eq!(widths.len(), 3);
+    for width in widths {
+      assert!((width - 1.0 / 3.0).abs() < f32::EPSILON);
+    }
+  }
+
+  #[test]
   fn distributes_even_stars() {
     // `*,C,*` with 4 side windows → two even stacks flanking the center.
     let kinds = parse_columns_spec("*,C,*").unwrap();
-    let columns =
-      distribute_columns(&kinds, 0, vec![1, 2, 3, 4], &ColumnBias::Left);
+    let columns = distribute_columns(
+      &kinds,
+      Some(0),
+      vec![1, 2, 3, 4],
+      &ColumnBias::Left,
+    );
     assert_eq!(columns, vec![vec![1, 2], vec![0], vec![3, 4]]);
   }
 
@@ -204,13 +246,21 @@ mod tests {
     let kinds = parse_columns_spec("*,C,*").unwrap();
 
     // Odd leftover: left bias gives the extra window to the first stack.
-    let left =
-      distribute_columns(&kinds, 0, vec![1, 2, 3], &ColumnBias::Left);
+    let left = distribute_columns(
+      &kinds,
+      Some(0),
+      vec![1, 2, 3],
+      &ColumnBias::Left,
+    );
     assert_eq!(left, vec![vec![1, 2], vec![0], vec![3]]);
 
     // Right bias gives it to the last stack.
-    let right =
-      distribute_columns(&kinds, 0, vec![1, 2, 3], &ColumnBias::Right);
+    let right = distribute_columns(
+      &kinds,
+      Some(0),
+      vec![1, 2, 3],
+      &ColumnBias::Right,
+    );
     assert_eq!(right, vec![vec![1], vec![0], vec![2, 3]]);
   }
 
@@ -219,8 +269,12 @@ mod tests {
     // `1,C` places one window in the fixed column and no `*` to absorb the
     // rest, so the leftovers land in the last non-center column.
     let kinds = parse_columns_spec("1,C").unwrap();
-    let columns =
-      distribute_columns(&kinds, 0, vec![1, 2, 3], &ColumnBias::Left);
+    let columns = distribute_columns(
+      &kinds,
+      Some(0),
+      vec![1, 2, 3],
+      &ColumnBias::Left,
+    );
     assert_eq!(columns, vec![vec![1, 2, 3], vec![0]]);
   }
 
@@ -231,11 +285,25 @@ mod tests {
     let kinds = parse_columns_spec("2,C,*").unwrap();
     let columns = distribute_columns(
       &kinds,
-      0,
+      Some(0),
       vec![1, 2, 3, 4, 5],
       &ColumnBias::Left,
     );
     assert_eq!(columns, vec![vec![1, 2], vec![0], vec![3, 4, 5]]);
+  }
+
+  #[test]
+  fn distributes_without_center() {
+    // No `C`: every window flows into the columns and none is pulled out
+    // as a privileged center (`center` is `None`).
+    let kinds = parse_columns_spec("*,*").unwrap();
+    let columns = distribute_columns(
+      &kinds,
+      None,
+      vec![1, 2, 3, 4],
+      &ColumnBias::Left,
+    );
+    assert_eq!(columns, vec![vec![1, 2], vec![3, 4]]);
   }
 
   #[test]

--- a/packages/wm/src/commands/workspace/focus_workspace.rs
+++ b/packages/wm/src/commands/workspace/focus_workspace.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use tracing::info;
 
-use super::activate_workspace;
+use super::{activate_workspace, reapply_assigned_columns};
 use crate::{
   commands::{
     container::set_focused_descendant, workspace::deactivate_workspace,
@@ -64,6 +64,10 @@ pub fn focus_workspace(
 
     set_focused_descendant(&container_to_focus, None);
     state.pending_sync.queue_focus_change();
+
+    // Reapply this workspace's columns (if any), now that its last-focused
+    // window is focused and will become the center.
+    reapply_assigned_columns(&target_workspace, None, state, config)?;
 
     // Display the workspace to switch focus to.
     state

--- a/packages/wm/src/commands/workspace/mod.rs
+++ b/packages/wm/src/commands/workspace/mod.rs
@@ -1,4 +1,5 @@
 mod activate_workspace;
+mod columns;
 mod deactivate_workspace;
 mod focus_workspace;
 mod move_workspace_in_direction;
@@ -6,6 +7,7 @@ mod sort_workspaces;
 mod update_workspace_config;
 
 pub use activate_workspace::*;
+pub use columns::*;
 pub use deactivate_workspace::*;
 pub use focus_workspace::*;
 pub use move_workspace_in_direction::*;

--- a/packages/wm/src/commands/workspace/move_workspace_in_direction.rs
+++ b/packages/wm/src/commands/workspace/move_workspace_in_direction.rs
@@ -2,7 +2,10 @@ use anyhow::Context;
 use wm_common::WmEvent;
 use wm_platform::Direction;
 
-use super::{activate_workspace, deactivate_workspace, sort_workspaces};
+use super::{
+  activate_workspace, deactivate_workspace, reapply_assigned_columns,
+  sort_workspaces, workspace_center_window_id,
+};
 use crate::{
   commands::container::move_container_within_tree,
   models::Workspace,
@@ -47,6 +50,11 @@ pub fn move_workspace_in_direction(
           .translate_to_center(&workspace.to_rect()?),
       );
     }
+
+    // Reapply the assigned columns so they re-tidy to the template on the
+    // new monitor, keeping the current center window centered.
+    let center = workspace_center_window_id(workspace);
+    reapply_assigned_columns(workspace, center, state, config)?;
 
     state
       .pending_sync

--- a/packages/wm/src/commands/workspace/update_workspace_config.rs
+++ b/packages/wm/src/commands/workspace/update_workspace_config.rs
@@ -38,6 +38,7 @@ pub fn update_workspace_config(
       .bind_to_monitor
       .or(current_config.bind_to_monitor),
     keep_alive: new_config.keep_alive.unwrap_or(current_config.keep_alive),
+    columns: current_config.columns.clone(),
   };
 
   workspace.set_config(updated_config);

--- a/packages/wm/src/events/handle_window_destroyed.rs
+++ b/packages/wm/src/events/handle_window_destroyed.rs
@@ -3,14 +3,22 @@ use tracing::info;
 use wm_platform::WindowId;
 
 use crate::{
-  commands::{window::unmanage_window, workspace::deactivate_workspace},
+  commands::{
+    window::unmanage_window,
+    workspace::{
+      deactivate_workspace, reapply_assigned_columns,
+      workspace_center_window_id,
+    },
+  },
   traits::{CommonGetters, WindowGetters},
+  user_config::UserConfig,
   wm_state::WmState,
 };
 
 pub fn handle_window_destroyed(
   native_window_id: WindowId,
   state: &mut WmState,
+  config: &UserConfig,
 ) -> anyhow::Result<()> {
   let found_window = state
     .windows()
@@ -20,6 +28,10 @@ pub fn handle_window_destroyed(
   // Unmanage the window if it's currently managed.
   if let Some(window) = found_window {
     let workspace = window.workspace().context("No workspace.")?;
+
+    // Note the current center before unmanaging so the reapply keeps it in
+    // place — closing a side window shouldn't move the center window.
+    let center = workspace_center_window_id(&workspace);
 
     info!("Window closed: {window}");
     unmanage_window(window, state)?;
@@ -31,6 +43,9 @@ pub fn handle_window_destroyed(
       && !workspace.is_displayed()
     {
       deactivate_workspace(workspace, state)?;
+    } else {
+      // Re-tidy the workspace's columns (if any) now a window's gone.
+      reapply_assigned_columns(&workspace, center, state, config)?;
     }
   }
 

--- a/packages/wm/src/events/handle_window_hidden.rs
+++ b/packages/wm/src/events/handle_window_hidden.rs
@@ -3,8 +3,13 @@ use wm_common::{DisplayState, HideMethod};
 use wm_platform::NativeWindow;
 
 use crate::{
-  commands::window::unmanage_window, traits::WindowGetters,
-  user_config::UserConfig, wm_state::WmState,
+  commands::{
+    window::unmanage_window,
+    workspace::{reapply_assigned_columns, workspace_center_window_id},
+  },
+  traits::{CommonGetters, WindowGetters},
+  user_config::UserConfig,
+  wm_state::WmState,
 };
 
 pub fn handle_window_hidden(
@@ -32,7 +37,19 @@ pub fn handle_window_hidden(
       || window.display_state() == DisplayState::Shown)
       && !window.native().is_visible().unwrap_or(false)
     {
+      let workspace = window.workspace();
+
+      // Note the current center before unmanaging so the reapply keeps it
+      // in place — closing a side window shouldn't move the center
+      // window.
+      let center = workspace.as_ref().and_then(workspace_center_window_id);
+
       unmanage_window(window, state)?;
+
+      // Re-tidy the workspace's columns (if any) now a window's gone.
+      if let Some(workspace) = workspace {
+        reapply_assigned_columns(&workspace, center, state, config)?;
+      }
     }
   }
 

--- a/packages/wm/src/events/handle_window_moved_or_resized_end.rs
+++ b/packages/wm/src/events/handle_window_moved_or_resized_end.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use uuid::Uuid;
 use wm_common::{
   try_warn, FullscreenStateConfig, TilingDirection, WindowState,
 };
@@ -8,11 +9,15 @@ use crate::{
   commands::{
     container::{move_container_within_tree, wrap_in_split_container},
     window::{set_window_size, update_window_state},
+    workspace::{
+      reapply_assigned_columns, reapply_columns_after_move,
+      workspace_center_rect, workspace_center_window_id,
+    },
   },
   events::update_floating_window_position,
   models::{
     DirectionContainer, NonTilingWindow, SplitContainer, TilingContainer,
-    WindowContainer,
+    WindowContainer, Workspace,
   },
   traits::{
     CommonGetters, PositionGetters, TilingDirectionGetters, WindowGetters,
@@ -109,8 +114,31 @@ pub fn handle_window_moved_or_resized_end(
       } else {
         // Window is a temporary floating window that should be
         // reverted back to tiling.
+
+        // Capture the source workspace's center — its window id and the
+        // rect it fills — before the drop mutates the tree, so a columns
+        // reapply can keep it in place, or hand the center to the dropped
+        // window when it lands on the center band.
+        let source_workspace = window.workspace();
+        let source_center = source_workspace
+          .as_ref()
+          .and_then(workspace_center_window_id);
+        let center_rect =
+          source_workspace.as_ref().and_then(workspace_center_rect);
+        let drop_x =
+          state.dispatcher.cursor_position().ok().map(|point| point.x);
+
         let window = drop_as_tiling_window(window, state, config)?;
         window.set_active_drag(None);
+
+        reapply_columns_after_drop(
+          source_workspace.as_ref(),
+          source_center,
+          dropped_onto_center(center_rect, drop_x),
+          &window,
+          state,
+          config,
+        )?;
       }
     }
     WindowContainer::TilingWindow(window) => {
@@ -144,6 +172,59 @@ pub fn handle_window_moved_or_resized_end(
   }
 
   Ok(())
+}
+
+/// Reintegrates a window that was just dropped back into tiling into its
+/// workspace's columns layout, replacing the ad-hoc splits from
+/// [`drop_as_tiling_window`] with the declarative grid.
+///
+/// Dropped within its `source_workspace`, the window takes the center when
+/// it landed on the center band (`onto_center`), otherwise it falls into
+/// the nearest column by position while `source_center` stays the center.
+/// Dropped onto a different columns workspace, it takes that workspace's
+/// center like a grid move. A no-op when neither workspace has columns.
+fn reapply_columns_after_drop(
+  source_workspace: Option<&Workspace>,
+  source_center: Option<Uuid>,
+  onto_center: bool,
+  window: &WindowContainer,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<()> {
+  let Some(dest_workspace) = window.workspace() else {
+    return Ok(());
+  };
+
+  match source_workspace {
+    Some(source) if source.id() != dest_workspace.id() => {
+      reapply_columns_after_move(
+        source,
+        source_center,
+        &dest_workspace,
+        window.id(),
+        state,
+        config,
+      )
+    }
+    _ => {
+      // Dropped onto the wide center → the window takes the center,
+      // displacing the old one into a side column; otherwise keep the
+      // pre-drop center and let the window slot in by position.
+      let preferred_center = if onto_center {
+        Some(window.id())
+      } else {
+        source_center
+      };
+
+      reapply_assigned_columns(
+        &dest_workspace,
+        preferred_center,
+        state,
+        config,
+      )
+      .map(|_| ())
+    }
+  }
 }
 
 /// Handles transition from temporary floating window to tiling window on
@@ -315,5 +396,54 @@ fn drop_position(mouse_pos: &Point, rect: &Rect) -> DropPosition {
     } else {
       DropPosition::Top
     }
+  }
+}
+
+/// Whether a window dropped at horizontal position `drop_x` landed on the
+/// wide center column, given the `center_rect` its window filled before
+/// the drop. True only when the workspace has a center and `drop_x` falls
+/// within that column's horizontal band, so the dropped window should take
+/// the center; otherwise the pre-drop center stays and the window slots
+/// into the nearest side column by position. `None` for either input (no
+/// center column, or no cursor reading) never takes the center.
+fn dropped_onto_center(
+  center_rect: Option<Rect>,
+  drop_x: Option<i32>,
+) -> bool {
+  let (Some(rect), Some(x)) = (center_rect, drop_x) else {
+    return false;
+  };
+
+  x >= rect.x() && x < rect.x() + rect.width()
+}
+
+#[cfg(test)]
+mod tests {
+  use wm_platform::Rect;
+
+  use super::dropped_onto_center;
+
+  /// A center column spanning x in `[600, 1000)`.
+  fn center() -> Option<Rect> {
+    Some(Rect::from_xy(600, 0, 400, 1080))
+  }
+
+  #[test]
+  fn drop_within_center_band_takes_center() {
+    assert!(dropped_onto_center(center(), Some(600)));
+    assert!(dropped_onto_center(center(), Some(700)));
+  }
+
+  #[test]
+  fn drop_outside_center_band_keeps_center() {
+    // Left of the band, and the right edge is exclusive.
+    assert!(!dropped_onto_center(center(), Some(200)));
+    assert!(!dropped_onto_center(center(), Some(1000)));
+  }
+
+  #[test]
+  fn no_center_or_no_cursor_never_takes_center() {
+    assert!(!dropped_onto_center(None, Some(700)));
+    assert!(!dropped_onto_center(center(), None));
   }
 }

--- a/packages/wm/src/test_utils.rs
+++ b/packages/wm/src/test_utils.rs
@@ -4,11 +4,12 @@
 //! mock builders in the model modules.
 
 use bon::bon;
+use tokio::sync::mpsc;
 use wm_common::{
-  FloatingStateConfig, GapsConfig, TilingDirection, WindowState,
-  WorkspaceConfig,
+  FloatingStateConfig, GapsConfig, ParsedConfig, TilingDirection,
+  WindowState, WorkspaceConfig,
 };
-use wm_platform::{Display, NativeWindow, Rect, RectDelta};
+use wm_platform::{Dispatcher, Display, NativeWindow, Rect, RectDelta};
 
 use crate::{
   commands::container::attach_container,
@@ -18,6 +19,8 @@ use crate::{
     Workspace,
   },
   traits::TilingSizeGetters,
+  user_config::UserConfig,
+  wm_state::WmState,
 };
 
 pub const MOCK_MONITOR_WIDTH: i32 = 1680;
@@ -47,6 +50,24 @@ pub fn mock_window_rect() -> Rect {
 
 pub fn mock_border_delta() -> RectDelta {
   RectDelta::zero()
+}
+
+/// Creates a `WmState` backed by a no-op `Dispatcher` for use in tests.
+///
+/// The event and exit channel receivers are dropped, so this is only
+/// suitable for commands that mutate the container tree and queue redraws
+/// (they never emit events during execution).
+pub fn mock_wm_state() -> WmState {
+  let (event_tx, _event_rx) = mpsc::unbounded_channel();
+  let (exit_tx, _exit_rx) = mpsc::unbounded_channel();
+
+  WmState::new(Dispatcher::mock(), event_tx, exit_tx)
+}
+
+/// Creates a `UserConfig` from the default `ParsedConfig` for use in
+/// tests.
+pub fn mock_user_config() -> UserConfig {
+  UserConfig::mock(ParsedConfig::default())
 }
 
 #[bon]
@@ -241,6 +262,7 @@ impl Workspace {
       display_name,
       bind_to_monitor: None,
       keep_alive: false,
+      columns: None,
     };
 
     let workspace = Self::new(config, gaps_config, tiling_direction);

--- a/packages/wm/src/user_config.rs
+++ b/packages/wm/src/user_config.rs
@@ -57,6 +57,21 @@ impl UserConfig {
     })
   }
 
+  /// Creates a `UserConfig` directly from an in-memory `ParsedConfig` for
+  /// use in tests, bypassing all file IO.
+  #[cfg(test)]
+  #[must_use]
+  pub fn mock(value: ParsedConfig) -> Self {
+    let window_rules_by_event = Self::window_rules_by_event(&value);
+
+    Self {
+      path: PathBuf::new(),
+      value,
+      value_str: String::new(),
+      window_rules_by_event,
+    }
+  }
+
   /// Reads and validates the user config from the given path.
   ///
   /// Creates a new config file from sample if it doesn't exist.

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -31,8 +31,11 @@ use crate::{
       update_window_state, WindowPositionTarget,
     },
     workspace::{
-      focus_workspace, move_workspace_in_direction,
-      update_workspace_config,
+      apply_center, apply_columns, apply_rotate, assign_columns,
+      effective_columns, focus_workspace, move_window_in_columns,
+      move_workspace_in_direction, reapply_assigned_columns,
+      unassign_columns, update_workspace_config,
+      workspace_center_window_id,
     },
   },
   events::{
@@ -138,7 +141,7 @@ impl WindowManager {
           handle_window_title_changed(&window, state, config)
         }
         WindowEvent::Destroyed { window_id, .. } => {
-          handle_window_destroyed(window_id, state)
+          handle_window_destroyed(window_id, state, config)
         }
       },
     }?;
@@ -336,16 +339,83 @@ impl WindowManager {
           _ => Ok(()),
         }
       }
+      InvokeCommand::Columns(args) => {
+        let workspace =
+          subject_container.workspace().context("No workspace.")?;
+
+        // A bare `columns` re-asserts the workspace's effective columns
+        // (its own assignment, or a monitor-shape-derived
+        // `general.default_columns` rule) rather than clobbering them with
+        // the command defaults, keeping the current center in place. Any
+        // explicit argument applies a one-shot layout instead.
+        if args.is_unset()
+          && effective_columns(&workspace, config)?.is_some()
+        {
+          let center = workspace_center_window_id(&workspace);
+          reapply_assigned_columns(&workspace, center, state, config)
+        } else {
+          apply_columns(
+            &workspace,
+            args.spec_or_default(),
+            args.center_or_default(),
+            &args.bias_or_default(),
+            None,
+            state,
+            config,
+          )
+        }
+      }
+      InvokeCommand::AssignColumns(args) => {
+        let workspace =
+          subject_container.workspace().context("No workspace.")?;
+
+        assign_columns(
+          &workspace,
+          args.spec_or_default(),
+          args.center_or_default(),
+          &args.bias_or_default(),
+          state,
+          config,
+        )
+      }
+      InvokeCommand::UnassignColumns => {
+        let workspace =
+          subject_container.workspace().context("No workspace.")?;
+
+        unassign_columns(&workspace);
+        Ok(())
+      }
+      InvokeCommand::Rotate(args) => {
+        let workspace =
+          subject_container.workspace().context("No workspace.")?;
+
+        apply_rotate(&workspace, args.ccw, state, config)
+      }
+      InvokeCommand::Center => {
+        let workspace =
+          subject_container.workspace().context("No workspace.")?;
+
+        apply_center(&workspace, state, config)
+      }
       InvokeCommand::Move(args) => {
         match subject_container.as_window_container() {
           Ok(window) => {
             if let Some(direction) = &args.direction {
-              move_window_in_direction(
-                window.clone(),
-                direction,
-                state,
-                config,
-              )?;
+              // Within a workspace's columns, move relocates the window
+              // inside the declarative grid; at the grid's edge (or with
+              // no columns) it falls back to the default
+              // mover, which carries the window to the
+              // neighbouring workspace/monitor.
+              if !move_window_in_columns(
+                &window, direction, state, config,
+              )? {
+                move_window_in_direction(
+                  window.clone(),
+                  direction,
+                  state,
+                  config,
+                )?;
+              }
             }
 
             if let Some(direction) = &args.workspace_in_direction {

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -353,6 +353,7 @@ impl WindowManager {
         {
           let center = workspace_center_window_id(&workspace);
           reapply_assigned_columns(&workspace, center, state, config)
+            .map(|_| ())
         } else {
           apply_columns(
             &workspace,

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -42,6 +42,15 @@ pub struct WmState {
   /// workspace focus.
   pub recent_workspace_name: Option<String>,
 
+  /// Id of the window most recently phased out of the center slot,
+  /// whether by the `center` command or by another window taking the
+  /// center (e.g. a freshly opened window that auto-centers).
+  ///
+  /// Lets `center` toggle: when the center window is focused, it swaps
+  /// back with this window, enabling fast switching between two
+  /// windows.
+  pub last_centered_out: Option<Uuid>,
+
   /// The previously focused window that had focus effects applied.
   ///
   /// Used to efficiently update window effects by only removing focus
@@ -89,6 +98,7 @@ impl WmState {
       pending_sync: PendingSync::default(),
       prev_effects_window: None,
       recent_workspace_name: None,
+      last_centered_out: None,
       unmanaged_or_minimized_timestamp: None,
       binding_modes: Vec::new(),
       ignored_windows: Vec::new(),

--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -40,6 +40,35 @@ general:
   # - 'false': Only show windows from the currently shown workspaces.
   show_all_in_taskbar: false
 
+  # A default centered-column layout applied to any workspace that has no
+  # `columns` of its own, chosen from the aspect ratio (`width / height`)
+  # of the monitor the workspace currently occupies. Rules are checked in
+  # order and the first matching band wins, so a workspace moved to a
+  # differently-shaped monitor automatically re-columns for it. A monitor
+  # matching no rule keeps the normal tiling layout.
+  #
+  # Each column `spec` is a comma-separated, left-to-right list: a number
+  # is a fixed stack of that many windows, `*` shares the leftover windows
+  # evenly, and `C` is the wide center (the focused window; exactly one).
+  # E.g. `*,C,*`, `C,*`, or `2,C,*`. Bounds are `min_aspect_ratio`
+  # (inclusive) and `max_aspect_ratio` (exclusive); a `spec` of `default`
+  # (or `none`) explicitly keeps normal tiling. Each rule may also set
+  # `center` (center width as a fraction of the workspace, default 0.6;
+  # the rest is split evenly across the other columns) and `bias` (which
+  # side wins an uneven `*` split, 'left'/'right', default 'left').
+  # default_columns:
+  #   # Ultrawide (~21:9 and wider): center flanked by two stacks.
+  #   - min_aspect_ratio: 2.1
+  #     spec: '*,C,*'
+  #     center: 0.5
+  #     bias: 'left'
+  #   # Standard widescreen (~16:9): center with a single side stack.
+  #   - min_aspect_ratio: 1.5
+  #     spec: 'C,*'
+  #     bias: 'right'
+  #   # Anything narrower: normal tiling.
+  #   - spec: default
+
 gaps:
   # Whether to scale the gaps with the DPI of the monitor.
   scale_with_dpi: true
@@ -122,6 +151,14 @@ window_behavior:
 
 workspaces:
   - name: '1'
+    # A workspace can pin its own centered-column layout, applied whenever
+    # it's focused and reapplied as windows are added, removed, or moved.
+    # This overrides `general.default_columns` for the workspace. Accepts
+    # a bare spec string (`columns: '*,C,*'`) or a full object:
+    # columns:
+    #   spec: '*,C,*'    # See `general.default_columns` for the spec grammar.
+    #   center: 0.6      # Center-column width, a fraction of the workspace.
+    #   bias: 'left'     # Which side wins an uneven `*` split ('left'/'right').
   - name: '2'
   - name: '3'
   - name: '4'


### PR DESCRIPTION
## Summary

Adds **declarative column layouts** — a centered-focus tiling mode where the
focused window occupies a wide center column and supporting windows tile into
columns on either side. You declare the shape once and GlazeWM keeps it applied
as windows open, close, and move.

## Why

Default tiling weighs every window equally, but many workflows have one window
that deserves the spotlight — an editor, a terminal, a browser — with references
and chat nearby but out of the way. Today that means manually resizing and
reshuffling every time a window opens or closes.

Column layouts make centered focus a first-class, declarative layout:

- **Centered focus.** The window you're working in stays wide and centered;
  everything else tiles alongside.
- **Easy swapping.** `center` pops any window into the spotlight (and back), so
  switching focus is one keybind.
- **Rotate.** `rotate` cycles windows through the slots without disturbing the shape.
- **Per-monitor shapes.** `default_columns` picks a layout from the monitor's
  aspect ratio — an ultrawide gets `*,C,*`, a smaller screen falls back to `C,*`
  or plain tiling — and a workspace re-columns automatically when moved between
  monitors.
- **Stays applied.** Open, close, or move a window and the layout re-tidies
  itself; no manual resizing.

## Spec grammar

A column `spec` is a comma-separated, left-to-right list of columns. Each token
is one column:

- `C` — the wide **center** column, holding the focused window. Exactly one `C`
  is required.
- a **number** (`1`, `2`, `3`, …) — a *fixed* stack holding exactly that many
  windows.
- `*` — a *flexible* stack that shares out whatever windows the fixed columns
  don't take, split evenly across all `*` columns.

Columns fill left-to-right. With six windows open (one focused, five others):

| Spec | Columns | Result |
| --- | --- | --- |
| `*,C,*` | flexible \| **center** \| flexible | `3 \| C \| 2` — the five side windows split evenly; the odd one goes left (see `bias`). |
| `2,C,*` | fixed 2 \| **center** \| flexible | `2 \| C \| 3` — the left column is capped at two, the right takes the rest. |
| `C,*,*` | **center** \| flexible \| flexible | `C \| 3 \| 2` — center on the left, the other five split across two columns. |
| `C,2,*` | **center** \| fixed 2 \| flexible | `C \| 2 \| 3` — center, then a fixed pair, then everything else. |

If the fixed columns can't hold every window and there's no `*` to absorb the
rest, the extra windows stack onto the last column so none are dropped.

**Widths.** `center` sets the center column's width as a fraction of the
workspace (`0.1`–`0.9`, default `0.6`); the remaining width is split *equally*
across the other columns, regardless of how many windows each stacks. `bias`
(`left`/`right`, default `left`) decides which side claims the odd window when a
`*` split isn't even.

## Config example

```yaml
general:
  # Pick a layout by monitor aspect ratio; first matching band wins.
  default_columns:
    - min_aspect_ratio: 2.1     # Ultrawide: center between two stacks.
      spec: "*,C,*"
      center: 0.5
    - min_aspect_ratio: 1.5     # Widescreen: center with one side stack.
      spec: "C,*"
      bias: "right"
    - spec: default             # Narrower: normal tiling.

workspaces:
  - name: "1"
    columns: "C,2,*"           # Center, a fixed pair, then the rest.
```

## Commands

- `columns [<spec>]` — apply a one-shot layout (bare `columns` re-asserts the assigned one)
- `assign-columns [<spec>]` / `unassign-columns` — set / clear a persistent layout
- `center` — swap the focused window into the center (toggles back)
- `rotate [--ccw]` — cycle windows through the slots, preserving the shape
- `move <direction>` — grid-aware within a layout

All accept `--center <fraction>` and `--bias left|right` where relevant.

## Docs

`README.md` gains a **Config: Columns** section; `sample-config.yaml` documents
`general.default_columns` and the per-workspace `columns` key inline.

## Screenshot

<img width="480" height="189" alt="tiling-demo" src="https://github.com/user-attachments/assets/ce463c24-7574-4cf5-b755-8b7b076ac715" />

## Implementation

Split into three focused modules under `commands/workspace/columns/`:

- `spec.rs` — pure parse + window-distribution math (unit-tested with plain indices)
- `grid.rs` — `ColumnGrid`, the container-tree ↔ grid bridge
- `mod.rs` — commands and config resolution

Covered by 8 spec unit tests and 17 command/e2e tests (25 total), including
fixed-column layouts and multi-monitor move-out / re-column behavior.
