### PR TITLE
fix: window swaps flash the desktop background + redundant alpha re-stamps flicker backdrop materials

### DIFF
--- a/packages/wm-platform/src/native_window.rs
+++ b/packages/wm-platform/src/native_window.rs
@@ -15,6 +15,8 @@ use crate::{platform_impl, Rect};
 use crate::{platform_impl::AXUIElementExt, ThreadBound};
 #[cfg(target_os = "windows")]
 use crate::{Color, CornerStyle, Delta, OpacityValue, RectDelta};
+#[cfg(target_os = "windows")]
+pub use crate::platform_impl::WindowPosBatch;
 
 /// Unique identifier of a window.
 ///
@@ -211,6 +213,21 @@ pub trait NativeWindowWindowsExt {
     flags: SET_WINDOW_POS_FLAGS,
   ) -> crate::Result<()>;
 
+  /// Adds this window's reposition to a [`WindowPosBatch`] transaction
+  /// instead of executing it immediately. All batched repositions land
+  /// atomically (same compositor frame) when the batch is committed.
+  ///
+  /// # Platform-specific
+  ///
+  /// This method is only available on Windows.
+  fn defer_window_pos(
+    &self,
+    batch: &mut WindowPosBatch,
+    z_order: &WindowZOrder,
+    rect: &Rect,
+    flags: SET_WINDOW_POS_FLAGS,
+  ) -> crate::Result<()>;
+
   /// Shows the window asynchronously.
   ///
   /// NOTE: Cloaked windows do not get shown until uncloaked.
@@ -366,6 +383,16 @@ impl NativeWindowWindowsExt for NativeWindow {
     flags: SET_WINDOW_POS_FLAGS,
   ) -> crate::Result<()> {
     self.inner.set_window_pos(z_order, rect, flags)
+  }
+
+  fn defer_window_pos(
+    &self,
+    batch: &mut WindowPosBatch,
+    z_order: &WindowZOrder,
+    rect: &Rect,
+    flags: SET_WINDOW_POS_FLAGS,
+  ) -> crate::Result<()> {
+    batch.defer(&self.inner, z_order, rect, flags)
   }
 
   fn show(&self) -> crate::Result<()> {

--- a/packages/wm-platform/src/platform_impl/mod.rs
+++ b/packages/wm-platform/src/platform_impl/mod.rs
@@ -7,5 +7,8 @@ mod platform;
 
 pub(crate) use platform::*;
 
+#[cfg(target_os = "windows")]
+pub use platform::WindowPosBatch;
+
 #[cfg(all(not(target_os = "windows"), not(target_os = "macos"),))]
 compile_error!("The platform you're compiling for is not supported.");

--- a/packages/wm-platform/src/platform_impl/windows/mod.rs
+++ b/packages/wm-platform/src/platform_impl/windows/mod.rs
@@ -14,5 +14,6 @@ pub(crate) use event_loop::*;
 pub(crate) use keyboard_hook::*;
 pub(crate) use mouse_listener::*;
 pub(crate) use native_window::*;
+pub use native_window::WindowPosBatch;
 pub(crate) use single_instance::*;
 pub(crate) use window_listener::*;

--- a/packages/wm-platform/src/platform_impl/windows/native_window.rs
+++ b/packages/wm-platform/src/platform_impl/windows/native_window.rs
@@ -21,6 +21,7 @@ use windows::{
         SendInput, INPUT, INPUT_0, INPUT_MOUSE, MOUSEINPUT,
       },
       WindowsAndMessaging::{
+        BeginDeferWindowPos, DeferWindowPos, EndDeferWindowPos,
         EnumWindows, GetAncestor, GetClassNameW, GetDesktopWindow,
         GetForegroundWindow, GetLayeredWindowAttributes, GetShellWindow,
         GetWindow, GetWindowLongPtrW, GetWindowRect, GetWindowTextW,
@@ -28,7 +29,8 @@ use windows::{
         IsZoomed, SendNotifyMessageW, SetForegroundWindow,
         SetLayeredWindowAttributes, SetWindowLongPtrW, SetWindowPlacement,
         SetWindowPos, ShowWindowAsync, WindowFromPoint, GA_ROOT,
-        GWL_EXSTYLE, GWL_STYLE, GW_OWNER, HWND_NOTOPMOST, HWND_TOP,
+        GWL_EXSTYLE, GWL_STYLE, GW_OWNER, HDWP, HWND_NOTOPMOST,
+        HWND_TOP,
         HWND_TOPMOST, LAYERED_WINDOW_ATTRIBUTES_FLAGS, LWA_ALPHA,
         LWA_COLORKEY, SET_WINDOW_POS_FLAGS, SWP_ASYNCWINDOWPOS,
         SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOCOPYBITS, SWP_NOMOVE,
@@ -47,6 +49,76 @@ use crate::{
   Color, CornerStyle, Delta, Dispatcher, LengthValue, OpacityValue, Point,
   Rect, RectDelta, WindowId, WindowZOrder,
 };
+
+/// A batched, atomic multi-window reposition transaction
+/// (`BeginDeferWindowPos` / `DeferWindowPos` / `EndDeferWindowPos`).
+///
+/// Every window deferred into the batch is repositioned in a single
+/// atomic operation at [`commit`], landing in the same compositor frame.
+/// This closes the background flash visible when windows exchange rects
+/// via individual `SetWindowPos` calls (especially async ones): the
+/// vacated region stays exposed for however many frames separate the
+/// two moves (diagnosed 2026-07-14 — window swaps flashing the desktop
+/// even with animations and transparency disabled).
+///
+/// [`commit`]: WindowPosBatch::commit
+pub struct WindowPosBatch {
+  hdwp: HDWP,
+}
+
+impl WindowPosBatch {
+  /// Begins a transaction sized for `capacity` windows. The OS grows the
+  /// internal structure automatically if more are deferred.
+  pub fn begin(capacity: i32) -> crate::Result<Self> {
+    let hdwp = unsafe { BeginDeferWindowPos(capacity) }?;
+    Ok(Self { hdwp })
+  }
+
+  /// Adds a window reposition to the transaction. Nothing moves until
+  /// [`commit`](WindowPosBatch::commit).
+  ///
+  /// `SWP_ASYNCWINDOWPOS` is stripped: a deferred transaction commits
+  /// synchronously by design. On failure the transaction is poisoned
+  /// (per the Win32 contract) and should be abandoned, not committed.
+  pub(crate) fn defer(
+    &mut self,
+    window: &NativeWindow,
+    z_order: &WindowZOrder,
+    rect: &Rect,
+    flags: SET_WINDOW_POS_FLAGS,
+  ) -> crate::Result<()> {
+    let z_order_hwnd = match z_order {
+      WindowZOrder::TopMost => HWND_TOPMOST,
+      WindowZOrder::Top => HWND_TOP,
+      WindowZOrder::Normal => HWND_NOTOPMOST,
+      WindowZOrder::AfterWindow(window_id) => HWND(window_id.0),
+    };
+
+    let flags = flags & !SWP_ASYNCWINDOWPOS;
+
+    self.hdwp = unsafe {
+      DeferWindowPos(
+        self.hdwp,
+        window.hwnd(),
+        z_order_hwnd,
+        rect.x(),
+        rect.y(),
+        rect.width(),
+        rect.height(),
+        flags,
+      )
+    }?;
+
+    Ok(())
+  }
+
+  /// Commits the transaction: every deferred reposition lands in one
+  /// atomic operation (a single compositor frame).
+  pub fn commit(self) -> crate::Result<()> {
+    unsafe { EndDeferWindowPos(self.hdwp) }?;
+    Ok(())
+  }
+}
 
 /// Magic number used to identify programmatic mouse inputs from our own
 /// process.
@@ -667,16 +739,38 @@ impl NativeWindow {
     &self,
     opacity_value: &OpacityValue,
   ) -> crate::Result<()> {
+    let target = opacity_value.to_alpha();
+
+    // Idempotence guard: re-applying an unchanged alpha is not free —
+    // `SetLayeredWindowAttributes` forces DWM to re-evaluate the window's
+    // composition, which visibly flickers system-backdrop materials
+    // (Acrylic/Mica) on windows that carry them. Effects passes re-apply
+    // transparency liberally (e.g. the all-windows pass queued on
+    // animation completion), so skip when the window is already layered
+    // at the target alpha (diagnosed 2026-07-14: window swaps flickering
+    // every glass window on screen).
+    unsafe {
+      let mut alpha = u8::MAX;
+      let mut flags = LAYERED_WINDOW_ATTRIBUTES_FLAGS::default();
+      if GetLayeredWindowAttributes(
+        self.hwnd(),
+        None,
+        Some(&raw mut alpha),
+        Some(&raw mut flags),
+      )
+      .is_ok()
+        && flags.contains(LWA_ALPHA)
+        && alpha == target
+      {
+        return Ok(());
+      }
+    }
+
     // Make the window layered if it isn't already.
     self.add_window_style_ex(WS_EX_LAYERED);
 
     unsafe {
-      SetLayeredWindowAttributes(
-        self.hwnd(),
-        None,
-        opacity_value.to_alpha(),
-        LWA_ALPHA,
-      )?;
+      SetLayeredWindowAttributes(self.hwnd(), None, target, LWA_ALPHA)?;
     }
 
     Ok(())

--- a/packages/wm/src/commands/general/platform_sync.rs
+++ b/packages/wm/src/commands/general/platform_sync.rs
@@ -207,6 +207,15 @@ fn redraw_containers(
   // Get monitors by their optimal hide corner.
   let monitors_by_hide_corner = state.monitors_by_hide_corner();
 
+  // Plain repositions are collected here and committed atomically after
+  // the loop via a `DeferWindowPos` transaction. Individual (especially
+  // `SWP_ASYNCWINDOWPOS`) repositions land frames apart per-app, so two
+  // windows exchanging rects expose the desktop in the vacated slot
+  // between the two moves — a visible background flash on every swap.
+  #[cfg(target_os = "windows")]
+  let mut deferred_repositions: Vec<(WindowContainer, Rect, WindowZOrder)> =
+    Vec::new();
+
   for window in windows_to_update.iter().rev() {
     let should_bring_to_front = windows_to_bring_to_front.contains(window);
 
@@ -285,7 +294,34 @@ fn redraw_containers(
       DisplayState::Showing | DisplayState::Shown
     );
 
-    if let Err(err) =
+    // A plain reposition of an ordinary, steady-state-visible window is
+    // batchable: it takes the catch-all `SetWindowPos` arm of
+    // `reposition_window` with no restore, no DPI fix-up, and a no-op
+    // visibility step. Anything state-special keeps the individual path.
+    #[cfg(target_os = "windows")]
+    let batchable = is_visible
+      && matches!(window.display_state(), DisplayState::Shown)
+      && window.active_drag().is_none()
+      && !window.has_pending_dpi_adjustment()
+      && matches!(
+        window.state(),
+        WindowState::Tiling | WindowState::Floating(_)
+      )
+      && !window.native().is_minimized().unwrap_or(true)
+      && !window.native().is_maximized().unwrap_or(true);
+    #[cfg(not(target_os = "windows"))]
+    let batchable = false;
+
+    if batchable {
+      #[cfg(target_os = "windows")]
+      {
+        let rect = window
+          .to_rect()?
+          .apply_delta(&window.total_border_delta()?, None);
+
+        deferred_repositions.push(((*window).clone(), rect, z_order.clone()));
+      }
+    } else if let Err(err) =
       reposition_window(window, *hide_corner, &z_order, is_visible, config)
     {
       tracing::warn!("Failed to set window position: {}", err);
@@ -332,7 +368,89 @@ fn redraw_containers(
     }
   }
 
+  // Commit all plain repositions collected above in a single atomic
+  // `DeferWindowPos` transaction, so windows exchanging rects (swaps)
+  // land in the same compositor frame with no exposed gap.
+  #[cfg(target_os = "windows")]
+  flush_deferred_repositions(&deferred_repositions, config);
+
   Ok(())
+}
+
+/// Commits the plain repositions collected during the redraw loop in a
+/// single atomic `DeferWindowPos` transaction.
+///
+/// A lone entry takes the historical individual (async) path — identical
+/// behavior to before batching existed. Two or more entries commit
+/// atomically so exchanged rects land in the same compositor frame. On
+/// any batch failure, falls back to individual repositions.
+#[cfg(target_os = "windows")]
+fn flush_deferred_repositions(
+  entries: &[(WindowContainer, Rect, WindowZOrder)],
+  config: &UserConfig,
+) {
+  use wm_platform::{
+    WindowPosBatch, SWP_ASYNCWINDOWPOS, SWP_FRAMECHANGED, SWP_NOACTIVATE,
+    SWP_NOCOPYBITS, SWP_NOSENDCHANGING,
+  };
+
+  if entries.is_empty() {
+    return;
+  }
+
+  let flags =
+    SWP_NOACTIVATE | SWP_NOCOPYBITS | SWP_NOSENDCHANGING | SWP_FRAMECHANGED;
+
+  let individual =
+    |window: &WindowContainer, rect: &Rect, z_order: &WindowZOrder| {
+      if let Err(err) = window.native().set_window_pos(
+        z_order,
+        rect,
+        flags | SWP_ASYNCWINDOWPOS,
+      ) {
+        tracing::warn!("Failed to set window position: {}", err);
+      }
+    };
+
+  if entries.len() == 1 {
+    let (window, rect, z_order) = &entries[0];
+    individual(window, rect, z_order);
+  } else {
+    let atomic = (|| -> anyhow::Result<()> {
+      #[allow(clippy::cast_possible_truncation)]
+      let mut batch = WindowPosBatch::begin(entries.len() as i32)?;
+
+      for (window, rect, z_order) in entries {
+        window
+          .native()
+          .defer_window_pos(&mut batch, z_order, rect, flags)?;
+      }
+
+      batch.commit()?;
+      Ok(())
+    })();
+
+    if let Err(err) = atomic {
+      tracing::warn!(
+        "Atomic reposition batch failed ({err}); falling back to \
+         individual repositions."
+      );
+      for (window, rect, z_order) in entries {
+        individual(window, rect, z_order);
+      }
+    }
+  }
+
+  // Parity with `reposition_window`'s visibility step. All batched
+  // windows are steady-state visible, so both calls are no-ops kept for
+  // exact behavioral parity with the individual path.
+  for (window, _, _) in entries {
+    if config.value.general.hide_method == HideMethod::Cloak {
+      let _ = window.native().set_cloaked(false);
+    } else {
+      let _ = window.native().show();
+    }
+  }
 }
 
 fn reposition_window(


### PR DESCRIPTION
## Problem

Two independent, reproducible sources of visible flicker when tiled windows exchange positions (`move --direction` between two windows):

1. **The desktop flashes in the vacated slot.** Each window is repositioned with its own `SetWindowPos` call under `SWP_ASYNCWINDOWPOS`, so the two moves are queued to each app's own thread and land frames apart — the region one window vacates stays exposed (showing the desktop/background) until the other window's move lands. Reproducible with transparency effects disabled; most visible with two windows of the same size swapping slots.

2. **Backdrop materials blink on effect passes.** `set_transparency` re-fires `SetLayeredWindowAttributes` even when the value is unchanged. A redundant re-stamp isn't free: DWM re-evaluates the window's composition, which visibly flickers system-backdrop materials (Acrylic/Mica) on windows that carry them (e.g. Windows Terminal with acrylic, Firefox with Mica, Explorer). Effects passes re-apply transparency liberally, so any sync that touches effects blinks every glass window on screen.

## Fix

1. **Atomic repositions**: plain repositions (ordinary, steady-state-visible windows — no restore, no DPI fix-up, no minimize/maximize/fullscreen special-casing, no active drag) are collected during the redraw loop and committed in a single `BeginDeferWindowPos`/`EndDeferWindowPos` transaction after it, so all rects land in the same compositor frame. A lone entry keeps the historical individual async path; anything state-special keeps the individual `reposition_window` path unconditionally. On any batch failure it falls back to individual repositions.

2. **Idempotent alpha**: `set_transparency` reads the current layered attributes first and returns early when the window is already layered at the target alpha.

## Notes

- `WindowPosBatch` is a small RAII-ish wrapper in `wm-platform` around the defer APIs; `SWP_ASYNCWINDOWPOS` is stripped inside the batch (deferred transactions commit synchronously by design).
- The batch's synchronous commit matches the pre-existing trade-off documented for surrogate-adjacent repositioning; it only engages when 2+ plain repositions occur in one sync cycle.
- Developed and behavior-tested on a fork carrying additional features; this branch is the two general-purpose fixes cherry-picked onto current `main` and compile-verified against it.

Happy to split into two PRs if preferred.