### PR TITLE
fix: re-enable disabled macOS event taps

### DIFF
--- a/packages/wm-platform/src/platform_impl/macos/event_tap.rs
+++ b/packages/wm-platform/src/platform_impl/macos/event_tap.rs
@@ -1,0 +1,82 @@
+use objc2_core_foundation::{CFMachPort, CFRetained};
+use objc2_core_graphics::{CGEvent, CGEventType};
+
+use crate::{Dispatcher, ThreadBound};
+
+/// Handle to an event tap that can be accessed from its callback.
+#[derive(Debug, Default)]
+pub(super) struct EventTapHandle {
+  tap_port: Option<ThreadBound<CFRetained<CFMachPort>>>,
+}
+
+impl EventTapHandle {
+  /// Stores a retained reference to the event tap on its owning thread.
+  pub(super) fn set(
+    &mut self,
+    tap_port: &CFRetained<CFMachPort>,
+    dispatcher: &Dispatcher,
+  ) {
+    self.tap_port =
+      Some(ThreadBound::new(tap_port.clone(), dispatcher.clone()));
+  }
+
+  /// Re-enables the event tap when macOS reports that it was disabled.
+  ///
+  /// Returns whether the event is a tap-disabled notification and should
+  /// therefore bypass normal event processing.
+  pub(super) fn reenable_if_disabled(
+    &self,
+    event_type: CGEventType,
+  ) -> bool {
+    let reason = match event_type {
+      CGEventType::TapDisabledByTimeout => "callback timeout",
+      CGEventType::TapDisabledByUserInput => "user input",
+      _ => return false,
+    };
+
+    match self.tap_port.as_ref().map(ThreadBound::get_ref) {
+      Some(Ok(tap_port)) => {
+        CGEvent::tap_enable(tap_port, true);
+        tracing::warn!(reason, "Re-enabled disabled macOS event tap.");
+      }
+      Some(Err(err)) => {
+        tracing::error!(
+          reason,
+          %err,
+          "Failed to access disabled macOS event tap."
+        );
+      }
+      None => {
+        tracing::error!(
+          reason,
+          "Disabled macOS event tap is missing its callback handle."
+        );
+      }
+    }
+
+    true
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn identifies_event_tap_disabled_notifications() {
+    let handle = EventTapHandle::default();
+
+    assert!(handle.reenable_if_disabled(CGEventType::TapDisabledByTimeout));
+    assert!(
+      handle.reenable_if_disabled(CGEventType::TapDisabledByUserInput)
+    );
+  }
+
+  #[test]
+  fn ignores_normal_input_events() {
+    let handle = EventTapHandle::default();
+
+    assert!(!handle.reenable_if_disabled(CGEventType::KeyDown));
+    assert!(!handle.reenable_if_disabled(CGEventType::MouseMoved));
+  }
+}

--- a/packages/wm-platform/src/platform_impl/macos/keyboard_hook.rs
+++ b/packages/wm-platform/src/platform_impl/macos/keyboard_hook.rs
@@ -8,6 +8,7 @@ use objc2_core_graphics::{
   CGEventTapOptions, CGEventTapPlacement, CGEventTapProxy, CGEventType,
 };
 
+use super::event_tap::EventTapHandle;
 use crate::{Dispatcher, Error, Key, KeyCode, ThreadBound};
 
 /// A key event received from the keyboard hook.
@@ -62,6 +63,7 @@ impl KeyEvent {
 /// Data shared with the `CGEventTap` callback.
 struct CallbackData {
   callback: Box<dyn Fn(KeyEvent) -> bool + Send + Sync + 'static>,
+  event_tap: EventTapHandle,
 }
 
 /// A system-wide low-level keyboard hook.
@@ -89,6 +91,7 @@ impl KeyboardHook {
     let callback_ptr = {
       let data = Box::new(CallbackData {
         callback: Box::new(callback),
+        event_tap: EventTapHandle::default(),
       });
       Box::into_raw(data) as usize
     };
@@ -151,6 +154,12 @@ impl KeyboardHook {
       })
     }?;
 
+    // Make the event tap available to its callback before registering the
+    // run loop source, which is when callbacks can start being delivered.
+    let callback_data =
+      unsafe { &mut *(callback_ptr as *mut CallbackData) };
+    callback_data.event_tap.set(&tap_port, dispatcher);
+
     let loop_source =
       CFMachPort::new_run_loop_source(None, Some(&tap_port), 0)
         .ok_or_else(|| {
@@ -183,6 +192,12 @@ impl KeyboardHook {
       return unsafe { event.as_mut() };
     }
 
+    let data = unsafe { &*(user_info as *const CallbackData) };
+
+    if data.event_tap.reenable_if_disabled(event_type) {
+      return unsafe { event.as_mut() };
+    }
+
     // Extract the key code of the pressed/released key.
     let key_code = KeyCode(unsafe {
       CGEvent::integer_value_field(
@@ -204,8 +219,6 @@ impl KeyboardHook {
       event_flags,
     };
 
-    // Get callback from user data and invoke it.
-    let data = unsafe { &*(user_info as *const CallbackData) };
     let should_intercept = (data.callback)(key_event);
 
     if should_intercept {

--- a/packages/wm-platform/src/platform_impl/macos/mod.rs
+++ b/packages/wm-platform/src/platform_impl/macos/mod.rs
@@ -5,6 +5,7 @@ mod ax_value;
 mod display;
 mod display_listener;
 mod event_loop;
+mod event_tap;
 pub(crate) mod ffi;
 mod keyboard_hook;
 mod mouse_listener;

--- a/packages/wm-platform/src/platform_impl/macos/mouse_listener.rs
+++ b/packages/wm-platform/src/platform_impl/macos/mouse_listener.rs
@@ -13,6 +13,7 @@ use objc2_core_graphics::{
 };
 use tokio::sync::mpsc;
 
+use super::event_tap::EventTapHandle;
 use crate::{
   mouse_listener::MouseEventKind,
   platform_event::{MouseButton, MouseEvent, PressedButtons},
@@ -22,6 +23,9 @@ use crate::{
 /// Data shared with the `CGEventTap` callback.
 struct CallbackData {
   event_tx: mpsc::UnboundedSender<MouseEvent>,
+
+  /// Handle used to re-enable the event tap from its callback.
+  event_tap: EventTapHandle,
 
   /// Pressed button state tracked from events.
   pressed_buttons: PressedButtons,
@@ -34,6 +38,7 @@ impl CallbackData {
   fn new(event_tx: mpsc::UnboundedSender<MouseEvent>) -> Self {
     Self {
       event_tx,
+      event_tap: EventTapHandle::default(),
       pressed_buttons: PressedButtons::default(),
       last_move_emission: None,
     }
@@ -172,6 +177,12 @@ impl MouseListener {
       })
     }?;
 
+    // Make the event tap available to its callback before registering the
+    // run loop source, which is when callbacks can start being delivered.
+    let callback_data =
+      unsafe { &mut *(callback_data_ptr as *mut CallbackData) };
+    callback_data.event_tap.set(&tap_port, dispatcher);
+
     let loop_source =
       CFMachPort::new_run_loop_source(None, Some(&tap_port), 0)
         .ok_or_else(|| {
@@ -237,6 +248,10 @@ impl MouseListener {
     }
 
     let data = unsafe { &mut *user_info.cast::<CallbackData>() };
+
+    if data.event_tap.reenable_if_disabled(cg_event_type) {
+      return unsafe { cg_event.as_mut() };
+    }
 
     // Map a `CGEventType` to a `MouseEventKind`.
     let event_kind = match cg_event_type {


### PR DESCRIPTION
## Summary

Fixes #1419. On macOS, `CGEventTap` is disabled by the system when its callback is too slow to respond (`kCGEventTapDisabledByTimeout`) or on certain user-input conditions (`kCGEventTapDisabledByUserInput`), most commonly around sleep/wake. Neither the keyboard hook nor the mouse listener handled these notifications, so once a tap was disabled it stayed disabled for the rest of the process lifetime — keybindings (and mouse events) would silently stop working until GlazeWM was restarted.

This adds a shared `EventTapHandle` (`wm-platform/src/platform_impl/macos/event_tap.rs`) that:
- Holds a thread-bound reference to the tap's `CFMachPort`, set up before the run loop source is registered.
- On receiving a `TapDisabledByTimeout`/`TapDisabledByUserInput` event in either callback, calls `CGEventTap::tap_enable(tap_port, true)` to re-enable the tap and logs a `warn!` with the reason, short-circuiting normal event processing for that callback invocation.
- Logs an `error!` if the tap handle can't be accessed, so failures aren't silent.

Wired into both `keyboard_hook.rs` and `mouse_listener.rs`, which share the same tap lifecycle pattern.

## Testing

- Ran the built binary continuously for ~2 days across multiple sleep/wake and lock/unlock cycles.
- Confirmed via debug logs that the tap was disabled and successfully re-enabled 9 times (`reason="callback timeout"`), with no keybinding freeze observed — previously this reproduced within ~1.5 days of uptime.
- Added unit tests in `event_tap.rs` covering disable-notification detection vs. normal event pass-through.
- `cargo test -p wm-platform` passes.

## Test plan

- [x] Reproduce original issue (keybindings freeze after sleep/wake) prior to fix
- [x] Confirm event tap re-enable log fires across multiple sleep/wake cycles
- [x] Confirm no keybinding freeze over multi-day uptime with the fix applied
- [x] Unit tests for tap-disabled event detection