### PR TITLE
fix #1417: shell-exec unable to launch programs surrounded by double quotes

### DIFF
--- a/packages/wm/src/commands/general/shell_exec.rs
+++ b/packages/wm/src/commands/general/shell_exec.rs
@@ -116,7 +116,7 @@ fn parse_command(
   if expanded_command.starts_with('"') {
     // Find the closing double quote.
     let (closing_index, _) =
-      expanded_command.match_indices('"').nth(2).ok_or_else(|| {
+      expanded_command.match_indices('"').nth(1).ok_or_else(|| {
         anyhow::anyhow!(
           "Shell exec failed for '{command}': command doesn't have an ending `\"`."
         )


### PR DESCRIPTION

This PR fixes #1417 by reducing the index by 1 for the command parser, as this will look at the second occurrence of " instead of the third.